### PR TITLE
added -d, --directory option documentation for arches-project command…

### DIFF
--- a/docs/command-line-reference.txt
+++ b/docs/command-line-reference.txt
@@ -31,6 +31,18 @@ Installs Arches into your virtual environment from a local clone of the `archesp
 
 in order to properly install all of Arches' python requirements. Make sure to use ``\`` instead of ``/`` on Windows.
 
+creating an Arches project
+--------------------------
+
+.. code-block:: bash
+
+   arches-project create <name_of_project> [{-d|--directory} <directory_name>]
+
+-d, --directory
+    (Optional) The name of the directory you'd like your new project located in.
+
+
+
 creating (or recreating) the database
 -------------------------------------
 
@@ -333,16 +345,6 @@ Common Options
 -i, --layer_icon  (Optional) The icon class to use for a Tileserver layer. Default: 'fa fa-globe'
 -b, --is_basemap  (Optional) Add this option to make the layer a basemap.
 
-
-Creating an Arches Project
-==========================
-
-.. code-block:: bash
-
-   arches-project create <name_of_project> [{-d|--directory} <directory_name>]
-
--d, --directory
-    (Optional) The name of the directory you'd like your new project located in.
 
 Other Useful Django Commands
 ============================

--- a/docs/command-line-reference.txt
+++ b/docs/command-line-reference.txt
@@ -334,11 +334,20 @@ Common Options
 -b, --is_basemap  (Optional) Add this option to make the layer a basemap.
 
 
+Creating an Arches Project
+==========================
+
+.. code-block:: bash
+
+   arches-project create <name_of_project> [{-d|--directory} <directory_name>]
+
+-d, --directory
+    (Optional) The name of the directory you'd like your new project located in.
 
 Other Useful Django Commands
 ============================
 
-run the django webserver
+Run the django webserver
 ------------------------
 
 .. code-block:: bash

--- a/docs/creating-a-development-environment.txt
+++ b/docs/creating-a-development-environment.txt
@@ -50,11 +50,14 @@ Setting Everything Up
 
     .. code-block:: bash
 
-        (ENV)$ arches-project create my_project [{-d|--directory} <directory_name>]
+        (ENV)$ arches-project create my_project
 
     or on Windows::
 
-        (ENV)\> ENV\Scripts\python.exe ENV\Scripts\arches-project create my_project [{-d|--directory} <directory_name>]
+        (ENV)\> ENV\Scripts\python.exe ENV\Scripts\arches-project create my_project
+
+    .. note:: You can use the option ``[{-d|--directory} <directory_name>]`` to change the directory your new project will be created in.
+
 
 #. You can now enter your new project and create a package
 

--- a/docs/creating-a-development-environment.txt
+++ b/docs/creating-a-development-environment.txt
@@ -50,11 +50,11 @@ Setting Everything Up
 
     .. code-block:: bash
 
-        (ENV)$ arches-project create my_project
+        (ENV)$ arches-project create my_project [{-d|--directory} <directory_name>]
 
     or on Windows::
 
-        (ENV)\> ENV\Scripts\python.exe ENV\Scripts\arches-project create my_project
+        (ENV)\> ENV\Scripts\python.exe ENV\Scripts\arches-project create my_project [{-d|--directory} <directory_name>]
 
 #. You can now enter your new project and create a package
 

--- a/docs/installation.txt
+++ b/docs/installation.txt
@@ -51,15 +51,20 @@ Use the following to get the latest stable release of Arches::
 
 Now that Arches is installed, you can make a Project. This is where you will make all of the customizations and branding that will make one installation of Arches different from the next. The name of your project should only be lowercase, and should use underscores instead of spaces or hyphens. The example below uses `my_project`.
 
+.. note:: If this command ends in an error related to yarn, you will need to enter ``my_project\my_project\`` (the directory that contains ``package.json``) and run this command: ``yarn install``.
+
 Linux and macOS::
 
-    arches-project create my_project [{-d|--directory} <directory_name>]
+    arches-project create my_project
 
 Windows::
 
-    python ENV\Scripts\arches-project create my_project [{-d|--directory} <directory_name>]
+    python ENV\Scripts\arches-project create my_project
 
-.. note:: If this command ends in an error related to yarn, you will need to enter ``my_project\my_project\`` (the directory that contains ``package.json``) and run this command: ``yarn install``.
+
+.. note:: You can use the option ``[{-d|--directory} <directory_name>]`` to change the directory your new project will be created in.
+
+
 
 6. Update settings_local.py
 ---------------------------

--- a/docs/installation.txt
+++ b/docs/installation.txt
@@ -53,11 +53,11 @@ Now that Arches is installed, you can make a Project. This is where you will mak
 
 Linux and macOS::
 
-    arches-project create my_project
+    arches-project create my_project [{-d|--directory} <directory_name>]
 
 Windows::
 
-    python ENV\Scripts\arches-project create my_project
+    python ENV\Scripts\arches-project create my_project [{-d|--directory} <directory_name>]
 
 .. note:: If this command ends in an error related to yarn, you will need to enter ``my_project\my_project\`` (the directory that contains ``package.json``) and run this command: ``yarn install``.
 
@@ -108,15 +108,15 @@ Now that you have Arches installed and a Project created, you are ready to begin
 * Modify some :doc:`Initial Configuration </initial-configuration>` settings
 
 * Read more about :doc:`Projects and Packages </projects-and-packages>`
-    
+
 * For a quick start that will create an example database schema in your new Arches project (and allow you to begin recording data right away), you can **load a sample package** with the following command
 
     .. code:: bash
-    
+
         python manage.py packages -o load_package -s https://github.com/archesproject/arches4-example-pkg/archive/master.zip -db true
 
     This example package has a full set of Resource Models, Branches, and Concepts that are generally based on the original :ref:`Arches HIP Contents`.
-    
+
     .. note:: If you get an "invalid package source" error, please download the zipfile (use the url in the command) and run the same command pointing to the location of the downloaded zipfile.
 
 General Troubleshooting
@@ -131,15 +131,15 @@ General Troubleshooting
 * Getting a connection error like this (in the dev server output or in the browser)
 
     .. error:: `ConnectionError: ConnectionError(<urllib3.connection.HTTPConnection object at 0x0000000005C6BC50>: Failed to establish a new connection: [Errno 10061] No connection could be made because the target machine actively refused it) caused by: NewConnectionError(<urllib3.connection.HTTPConnection object at 0x0000000005C6BC50>: Failed to establish a new connection: [Errno 10061] No connection could be made because the target machine actively refused it)`
-    
+
     means Arches is not able to communicate with ElasticSearch. Most likely, ElasticSearch is just not running, so just start it up and reload the page. If you can confirm that it `is` running, make sure Arches is pointed to to correct port.
 
 * Postgres password authentication error
 
     .. error:: `django.db.utils.OperationalError: FATAL: pw authentification  failed for user postgres`
-        
+
     Most likely you have not correctly set the database credentials in your ``settings.py`` file. Many of our install scripts set the db user to ``postgres`` and password to ``postgis``, so that's what Arches looks for by default. However, if you have changed these values (particularly if you are on Windows and had to enter a password during the Postgres/PostGIS installation process), the new values must be reflected in in ``settings.py`` or ``settings_local.py``.
-    
+
     .. note::
-    
+
         On Windows, you can avoid having to repeatedly enter the password while running commands in the console by setting the PGPASSWORD environment variable: ``set PGPASSWORD=<your password>``.

--- a/docs/projects-and-packages.txt
+++ b/docs/projects-and-packages.txt
@@ -84,7 +84,10 @@ If you are a developer running the latest arches you probably want to create a p
 
         .. code-block:: bash
 
-            arches-project create mynewproject [{-d|--directory} <directory_name>]
+            arches-project create mynewproject
+
+        .. note:: You can use the option ``[{-d|--directory} <directory_name>]`` to change the directory your new project will be created in.
+
 
     #. Finally run the `load_package` command using the project's manage.py file.
 

--- a/docs/projects-and-packages.txt
+++ b/docs/projects-and-packages.txt
@@ -84,9 +84,9 @@ If you are a developer running the latest arches you probably want to create a p
 
         .. code-block:: bash
 
-            arches-project create mynewproject
+            arches-project create mynewproject [{-d|--directory} <directory_name>]
 
-    #. Finally run the `load_package` command using the projects manage.py file.
+    #. Finally run the `load_package` command using the project's manage.py file.
 
         .. code-block:: bash
 


### PR DESCRIPTION
… for #6 

Added a section to the Command Line Reference, and added the proper-form inline documentation everywhere else the command appears. Perhaps it might not be adviseable to include everywhere if we're trying to make things easy to copy-paste for the non-technical user; feedback welcome. 

Added a couple neighboring typo fixes while under the hood. My emacs, as usual, cleared whitespace on otherwise unoccupied lines.