### PR TITLE
rm install scrips (outdated), name JDK v8, specify instruction for wi…

### DIFF
--- a/docs/requirements-and-dependencies.txt
+++ b/docs/requirements-and-dependencies.txt
@@ -19,9 +19,6 @@ To begin development or make a test installation of Arches, you will need the fo
 Software Dependencies
 =====================
 
-**Linux/Unix** `Installation scripts <https://github.com/archesproject/arches/tree/master/arches/install>`_. These do not install Elasticsearch (see below).
-
-**macOS** `Development installation script <https://gist.github.com/jmunowitch/35eb1d20a0b9cbf86f4b0eb4b167d43a>`_. Running this script in full will create an installation of Arches based on the current repo, but you can use pieces of it for individual dependencies as well.
 
 To familiarize yourself with the components and learn some important details, please
 read the notes below. Where necessary, Windows installation notes are included as well.
@@ -36,8 +33,9 @@ read the notes below. Where necessary, Windows installation notes are included a
 :Elasticsearch 7.4: - Installers: https://www.elastic.co/downloads/past-releases/elasticsearch-7-4-0
     - Elasticsearch is integral to Arches and can be installed and configured many ways.
       For more information, see :ref:`Arches and Elasticsearch`.
-:JDK: - `Only required to support a local installation of Elasticsearch`
-    - **Windows** Use `this installer <http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html>`_. Once installed, find Java on your operating system, it will be somewhere like ``C:\Program Files\Java\jdk*.*.*_**``. Now take that full path, and add it to the ``JAVA_HOME`` system environment variable.
+:JDK 8: - `Only required to support a local installation of Elasticsearch`
+    - `Installers <http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html>`_. 
+    - **Windows** Once installed, find Java on your operating system, it will be somewhere like ``C:\Program Files\Java\jdk*.*.*_**``. Now take that full path, and add it to the ``JAVA_HOME`` system environment variable.
 :GDAL > 1.11.5 and GEOS: - **Windows** Use the `OSGeo4W installer <https://trac.osgeo.org/osgeo4w/>`_, and choose to install the GDAL package (you don't need QGIS or GRASS). After installation, add ``C:\OSGeo4W64\bin`` to your system's ``PATH`` environment variable.
     - **macOS** Use version 3.6.1 (3.6.2 has caused trouble).
 :Yarn: - Installation: https://yarnpkg.com/lang/en/docs/install


### PR DESCRIPTION
…ndows as separate from url path to download jdk installers, re #144

### brief description of changes
<!-- please describe the changes here -->
- Updates arches software dependencies ahead of v5 release
- specifies JDK 8 as target version, clarifies instructions
- removes outdated install scripts for linux and mac OS

#### further comments
<!-- feel free to delete this header if you have no comments -->

---

This box **must** be checked
- [x] the PR branch was originally made from the base branch

This box **should** be checked
- [ ] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [ ] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
