### PR TITLE
direct installation of GDAL 2.x and link to UCLA tutorial (thanks!!) #152

### DIFF
--- a/docs/requirements-and-dependencies.txt
+++ b/docs/requirements-and-dependencies.txt
@@ -37,7 +37,7 @@ read the notes below. Where necessary, Windows installation notes are included a
       For more information, see :ref:`Arches and Elasticsearch`.
 :JDK: - `Only required to support a local installation of Elasticsearch`
     - **Windows** Use `this installer <http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html>`_. Once installed, find Java on your operating system, it will be somewhere like ``C:\Program Files\Java\jdk*.*.*_**``. Now take that full path, and add it to the ``JAVA_HOME`` system environment variable.
-:GDAL > 1.11.5 and GEOS: - **Windows** Use the `OSGeo4W installer <https://trac.osgeo.org/osgeo4w/>`_, and choose to install the GDAL package (you don't need QGIS or GRASS). After installation, add ``C:\OSGeo4W64\bin`` to your system's ``PATH`` environment variable.
+:GDAL and GEOS: - **Windows** Use GDAL 2.x. We recommend following `this tutorial <https://sandbox.idre.ucla.edu/sandbox/tutorials/installing-gdal-for-windows>`_ which will direct you to download and install the appropriate installers from `gisinternals.com/archive.php <http://www.gisinternals.com/archive.php>`_.
     - **macOS** Use version 3.6.1 (3.6.2 has caused trouble).
 :Yarn: - Installation: https://yarnpkg.com/lang/en/docs/install
     - **Windows** Use the .msi installer in the link above, but first install `Node.js <https://nodejs.org/>`_.


### PR DESCRIPTION
### brief description of changes
We've found that GDAL 3 is not supported in Django 1.11. However, that is the GDAL version that the current OSGEO4W installer currently installs, so our documentation was directing people to download an incompatible version of GDAL. This fixes that by directing them to a different installation tutorial that supports the installation of older releases.

#### issues addressed
#152 

#### further comments
this fix is only applied to the 4.4.3 branch (stable) as we don't anticipate this to be a problem with Arches 5 that uses Django 2.

---

This box **must** be checked
- [ ] the PR branch was originally made from the base branch

This box **should** be checked
- [x] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [x] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged (N/A)
