### PR TITLE
Warns users of generic relationship deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 docs/_build
+.vscode

--- a/docs/creating-new-map-layers.txt
+++ b/docs/creating-new-map-layers.txt
@@ -25,63 +25,6 @@ Additionally, you can take a MapBox JSON file and place any mapbox.js layer defi
 
 .. note:: One thing to be aware of when trying to cascade a WMS through a MapBox layer is that mapbox.js is `much pickier <https://github.com/mapbox/mapbox-gl-js/issues/2171>`_ about CORS than other js mapping libraries like Leaflet. To use an external WMS or tileset, you may be better off using a tileserver layer as described below. You can find WMS examples in the `arches4-geo-examples <https://github.com/legiongis/arches4-geo-examples>`_ repo.
 
-Tileserver Vector Layers
-````````````````````````
-
-``python manage.py packages -o add_tileserver_layer -t /path/to/tileserver_config.json -n "New Tileserver Layer"``
-
-Arches comes with an embedded tileserver called `TileStache <http://tilestache.org/>`_, which allows Arches to generate tiles internally from many different data sources. In fact, this tileserver is what creates layers from your database resources that are visible on the map.
-
-To add a new tileserver layer, you need a .json file that contains a TileStache-compliant layer definition. Within this file, you can use any of the many different data `provider classes <http://tilestache.org/doc/#layers>`_ from Tilestache. The .json file that you load into Arches for a tileserver layer should have three sections::
-
-    {
-        "type" :   ## This value should be "raster" or "vector".
-        "layers" : ## This is a mapbox.js layer definition which defines the style
-                   ## of the layer and links the source name with the layer name.
-        "config" : ## This is the tileserver configuration that will be used by
-                   ## TileStache. Refer to TileStache docs and place the entire
-                   ## "provider" section into this "config" section.
-    }
-
-Here's a full example of a tilestache file that makes a layer from data in PostGIS (a table called "rivers")::
-
-    {
-        "type": "vector",
-        "layers": [{
-            "id": "rivers",
-            "type": "line",
-            "source": "rivers",
-            "source-layer": "rivers",
-            "layout": {
-                "visibility": "visible"
-            },
-            "paint": {
-                "line-width": 2,
-                "line-color": "rgb(37, 58, 241)"
-            }
-        }],
-        "config": {
-            "provider": {
-                "class": "TileStache.Goodies.VecTiles:Provider",
-                "kwargs": {
-                    "dbinfo": {
-                        "host": "localhost",
-                        "user": "postgres",
-                        "password": "postgis",
-                        "database": "arches",
-                        "port": "5432"
-                    },
-                    "simplify": 0.5,
-                    "queries": [
-                        "select gid as __id__, name, st_asgeojson(geom) as geojson, st_transform(geom, 900913) as __geometry__ from rivers"
-                    ]
-                }
-            },
-            "allowed origin": "*",
-            "compress": true,
-            "write cache": false
-        }
-    }
 
 Making Selectable Vector Layers
 -------------------------------
@@ -152,27 +95,3 @@ You can display custom HTML in the search map popup when a user hovers or clicks
 4. Add the overlay as you would any tileserver layer (see above).
 
 You will now be able to add this layer to the map see the markup defined in the 'feature_info_content' in the search map popup.
-
-Tileserver Mapnik Layers
-````````````````````````
-
-``python manage.py packages -o add_tileserver_layer -m /path/to/mapnik_config.xml -n "New Mapnik Tileserver Layer"``
-
-Mapnik is the provider that TileStache uses to serve rasters, and is very commonly used in Arches. Arches allows you to upload a Mapnik XML file to configure a new tileserver layer, instead of creating the full JSON file. This is the **easiest way to make layers from GeoTiffs and shapefiles**. A basic example of a Mapnik XML file is shown below (it points to a geotiff named ``hillshade.tif``). For more about creating these XML files, see the `Mapnik XML reference <https://github.com/mapnik/mapnik/wiki/XMLConfigReference>`_::
-
-    <Map background-color="transparent">
-        <Layer name="Hillshade">
-            <StyleName>raster</StyleName>
-            <Datasource>
-                <Parameter name="type">gdal</Parameter>
-                <Parameter name="file">hillshade.tif</Parameter>
-                <Parameter name="nodata">0</Parameter>
-            </Datasource>
-        </Layer>
-        <Style name="raster">
-            <Rule name="rule 1">
-                <RasterSymbolizer opacity=".7" scaling="bilinear" mode="normal" />
-            </Rule>
-        </Style>
-    </Map>
-

--- a/docs/creating-resources.txt
+++ b/docs/creating-resources.txt
@@ -66,6 +66,12 @@ If you are a member of the Resource Editor group, all of your edits--either crea
 Related Resources
 ````````````````````````````
 
+.. warning::
+
+    Managing generic relationships as described below is still an available feature in Arches. However, **this feature will soon be deprecated** in a future release. 
+    Users are strongly encouraged to use the `resource-instance` datatype to manage relationships between resource instances.
+    The ability to visualize connections across `resource-instance` datatype nodes will accompany the deprecation of the generic resource relationship. 
+
 From the Resource Editor you can also access the Related Resources Editor, which is used to create a relationship between this resource and another in your databas. To do so, open the editor, find the resource, and click Add. Your Resource Model will need to be configured to allow relations with the target Resource Model. If relations are not allowed, resources in the dropdown menu will not be selectable.
 
 After a relation has been created, you can further refine its properties, such as what type of relation it is, how long it lasted, etc. While viewing the relation in grid mode, begin by selecting the relation in the table. You will see the "Delete Selected" button appear. Next click "relation properties", enter the information, and don't forget to "Save" when finished.

--- a/docs/requirements-and-dependencies.txt
+++ b/docs/requirements-and-dependencies.txt
@@ -37,7 +37,7 @@ read the notes below. Where necessary, OS-specific installation notes are includ
 :JDK 8: - `Only required to support a local installation of Elasticsearch`
     - `Installers <http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html>`_. 
     - **Windows** Once installed, find Java on your operating system, it will be somewhere like ``C:\Program Files\Java\jdk*.*.*_**``. Now take that full path, and add it to the ``JAVA_HOME`` system environment variable.
-:GDAL > 1.11.5 and GEOS: - **Windows** Use the `OSGeo4W installer <https://trac.osgeo.org/osgeo4w/>`_, and choose to install the GDAL package (you don't need QGIS or GRASS). After installation, add ``C:\OSGeo4W64\bin`` to your system's ``PATH`` environment variable.
+:GDAL > 1.11.5: - **Windows** Use the `OSGeo4W installer <https://trac.osgeo.org/osgeo4w/>`_, and choose to install the GDAL package (you don't need QGIS or GRASS). After installation, add ``C:\OSGeo4W64\bin`` to your system's ``PATH`` environment variable.
     - **macOS** Use version 3.6.1 (3.6.2 has caused trouble).
 :Yarn: - Installation: https://yarnpkg.com/lang/en/docs/install
     - **Windows** Use the .msi installer in the link above, but first install `Node.js <https://nodejs.org/>`_.


### PR DESCRIPTION
Removes tileserver command documentation and warns users that the generic resource relationship pattern will be deprecated in favor of using the resource-instance datatype. re #162 