### PR TITLE
adds language to support mod-wsgi install on ubunutu 20.04, python 3,…

### DIFF
--- a/docs/import-export.txt
+++ b/docs/import-export.txt
@@ -620,7 +620,7 @@ Note that you'll have to provide the UUID for the Resource Model whose resources
 
 To export CSV, use::
 
-    python manage.py packages -o export_business_data -d 'path_to_destination_directory' -f 'csv' -c 'path_to_mapping_file'
+    python manage.py packages -o export_business_data -d 'path_to_destination_directory' -f 'csv' -c 'path_to_mapping_file' -g 'resource_model_uuid'
 
 When exporting to CSV, you need to use a :ref:`Mapping File`, which will determine the content of your CSV (which nodes are exported, etc.). Add the ``--single_file`` argument to export your grouped data to the same CSV file as the rest of your data.
 

--- a/docs/serving-arches-with-apache.txt
+++ b/docs/serving-arches-with-apache.txt
@@ -20,7 +20,7 @@ should get you started.
 Configure Apache
 ================
 
-The following instructions work for Ubuntu 16.04+, minor changes may be necessary for a different OS. This is a very basic Apache configuration, and more fine tuning
+The following instructions work for Ubuntu 16.04 - 18.04, see notes for Ubunutu 20.04; minor changes may be necessary for a different OS. This is a very basic Apache configuration, and more fine tuning
 will benefit your production installation.
 
 1. Install Apache.
@@ -29,14 +29,16 @@ will benefit your production installation.
 
        $ sudo apt-get install apache2
 
-2. Install ``mod_wsgi`` into your Arches virtual environment.
+2. Install ``mod_wsgi`` 
+
+    - For deployments on Ubuntu 16.04 - 18.04 you can ``pip`` install ``mod_wsgi`` into your Arches virtual environment.
 
     .. code-block:: bash
 
         $ source /home/ubuntu/Projects/ENV/bin/activate
         (ENV)$ pip install mod_wsgi
 
-3. Generate the link path to ``mod_wsgi``.
+    Generate the link path to ``mod_wsgi``.
 
     .. code-block:: bash
 
@@ -51,7 +53,16 @@ will benefit your production installation.
 
     Copy these two lines, you will use them in the next step.
 
-4.  Create a new Apache .conf file
+    - For deployments on ubunutu 20.04+, ``mod-wsgi`` may not be installable via ``pip`` and ``apt`` can be used:
+
+    .. code-block:: bash
+        $ sudo apt install libapache2-mod-wsgi-py3 apache2-dev python3-dev
+
+    Note that the version of Python 3 installed at the system-level may need to match the version used to create the virtual environment pointed to in the config.
+    For example, if ``libapache2-mod-wsgi-py3`` is compiled against Python 3.8, use Python 3.8 for your virtual environment.
+    Installing ``mod-wsgi`` this way means you will not need to load it as a module in the config file.
+
+3.  Create a new Apache .conf file
 
     Here is a basic Apache configuration for Arches. If using a domain
     like ``heritage-inventory.org``, name this file ``heritage-inventory.org.conf``,
@@ -117,7 +128,7 @@ will benefit your production installation.
 
         </VirtualHost>
 
-5. Disable the default Apache conf, and enable the new one.
+4. Disable the default Apache conf, and enable the new one.
 
     .. code-block::
 

--- a/docs/serving-arches-with-apache.txt
+++ b/docs/serving-arches-with-apache.txt
@@ -20,7 +20,7 @@ should get you started.
 Configure Apache
 ================
 
-The following instructions work for Ubuntu 16.04 - 18.04, see notes for Ubunutu 20.04; minor changes may be necessary for a different OS. This is a very basic Apache configuration, and more fine tuning
+The following instructions work for Ubuntu 16.04 - 20.04; minor changes may be necessary for a different OS. This is a very basic Apache configuration, and more fine tuning
 will benefit your production installation.
 
 1. Install Apache.
@@ -31,7 +31,7 @@ will benefit your production installation.
 
 2. Install ``mod_wsgi`` 
 
-    - For deployments on Ubuntu 16.04 - 18.04 you can ``pip`` install ``mod_wsgi`` into your Arches virtual environment.
+    - You can ``pip`` install ``mod_wsgi`` into your Arches virtual environment however you may need to have installed a python-dev package specific to your version of python3, for ex: ``apt-get install python3.8-dev``.
 
     .. code-block:: bash
 
@@ -53,7 +53,7 @@ will benefit your production installation.
 
     Copy these two lines, you will use them in the next step.
 
-    - For deployments on ubunutu 20.04+, ``mod-wsgi`` may not be installable via ``pip`` and ``apt`` can be used:
+    - As an alternative to ``pip`` installing ``mod-wsgi`` you can use ``apt`` to install at the system-level:
 
     .. code-block:: bash
         $ sudo apt install libapache2-mod-wsgi-py3 apache2-dev python3-dev


### PR DESCRIPTION
… re #240

### brief description of changes
<!-- please describe the changes here -->
The current documentation provides an installation path of ``mod-wsgi`` via ``pip``. It was found that as of ubuntu 20.04, using ``pip`` to install ``mod-wsgi`` via the virtual environment was unsuccessful. An alternate suggested path here is provided.

#### issues addressed
<!-- feel free to delete this header if the PR does not specifically address an issue -->
#240 

#### further comments
<!-- feel free to delete this header if you have no comments -->

---

This box **must** be checked
- [ ] the PR branch was originally made from the base branch

This box **should** be checked
- [ ] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [ ] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
