### PR TITLE
PR Merge branch Pipfile ignore into Master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 docs/_build
 .vscode
 .DS_Store
+
+# Virtual env, pyenv ignores
+.venv/
+Pipfile
+Pipfile.lock

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -186,7 +186,7 @@ html_static_path = ['_static']
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+html_extra_path = ['robots.txt',]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -6,3 +6,4 @@ Allow: /*/latest/
 Allow: /en/latest/   # Fallback for bots that don't understand wildcards
 Allow: /*/stable/
 Allow: /en/stable/   # Fallback for bots that don't understand wildcards
+Disallow: /

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,8 @@
+# Response to issue: https://github.com/archesproject/arches-docs/issues/297
+# See example: https://github.com/astropy/astropy/pull/7874/files
+
+User-agent: *
+Allow: /*/latest/
+Allow: /en/latest/   # Fallback for bots that don't understand wildcards
+Allow: /*/stable/
+Allow: /en/stable/   # Fallback for bots that don't understand wildcards


### PR DESCRIPTION
### brief description of changes

1. Added to gitignore to keep pyenv related files out of version control
2. Added a robots.txt file and config

#### issues addressed
1. Ergonomics to keep pipfile and pipfile.lock files for developers using pyenv
2. Need for a robots.txt file to direct search engine indexing to current documentation  https://github.com/archesproject/arches-docs/issues/297

#### further comments
I ran a build on ReadTheDocs to make sure that this actually works. I also checked the validity of the robots.txt directives using https://technicalseo.com/tools/robots-txt/

We should add the robots.txt file and updates conf.py commit to other release branches via cherry-pick
---

This box **must** be checked
- [x] the PR branch was originally made from the base branch

This box **should** be checked
- [x] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [x] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
