### PR TITLE
Added EDTF level support and bug workaround

### DIFF
--- a/docs/developing/reference/import-export.txt
+++ b/docs/developing/reference/import-export.txt
@@ -54,6 +54,16 @@ Must be a valid `Extended Date Time Format <https://www.loc.gov/standards/dateti
     "2010-10"
     "-y10000"
 
+Arches supports level 2 of the EDTF specification. However, because of a bug in the edtf package used by Arches,
+an error will be thrown for strings like::
+
+    "../1924"
+
+As a workaround, you can use a string like::
+
+    "[../1924]"
+
+
 geojson-feature-collection
 --------------------------
 
@@ -828,7 +838,7 @@ Directly inserting our records into the new Arches view will look something like
         name_type,
         resourceinstanceid,
         transactionid
-    ) select 
+    ) select
         name,
         "Primary",
         resourceid,


### PR DESCRIPTION
### brief description of changes
Updates description of the edtf datatype, level 2 support, and notes a bug and workaround for certain kinds of string values used with this datatype.

#### issues addressed
(https://github.com/archesproject/arches-docs/issues/298)

#### further comments
Thanks @mradamcox for describing exactly the documentation changes required.

---

This box **must** be checked
- [x] the PR branch was originally made from the base branch

This box **should** be checked
- [x] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [ ] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
