### PR TITLE
Added collector deprecation warning

### DIFF
--- a/docs/arches-collector-checklist.txt
+++ b/docs/arches-collector-checklist.txt
@@ -2,6 +2,13 @@
 Arches Collector Checklist
 ##########################
 
+.. warning::
+
+    Arches Collector has been deprecated and **does not** function with Arches v7.x and higher. For
+    more information about the deprecation of Arches Collector and future plans for mobile-apps,
+    please refer to <https://community.archesproject.org/t/arches-collector-update/1580>.
+
+
 The following steps must be completed to enable an Arches Collector connection
 with your Arches instance.
 

--- a/docs/arches-collector-manager.txt
+++ b/docs/arches-collector-manager.txt
@@ -2,6 +2,13 @@
 Arches Collector Manager
 ########################
 
+.. warning::
+
+    Arches Collector has been deprecated and **does not** function with Arches v7.x and higher. For
+    more information about the deprecation of Arches Collector and future plans for mobile-apps,
+    please refer to <https://community.archesproject.org/t/arches-collector-update/1580>.
+
+
 What Are Arches Collector Projects?
 ===================================
 

--- a/docs/using-arches-collector.txt
+++ b/docs/using-arches-collector.txt
@@ -2,6 +2,13 @@
 Introduction to Arches Collector
 ################################
 
+.. warning::
+
+    Arches Collector has been deprecated and **does not** function with Arches v7.x and higher. For
+    more information about the deprecation of Arches Collector and future plans for mobile-apps,
+    please refer to <https://community.archesproject.org/t/arches-collector-update/1580>.
+
+
 .. image:: images/arches-mobile/apple-app-store.png
     :height: 50px
     :target: https://apps.apple.com/us/app/arches-collector/id1377842164


### PR DESCRIPTION
### brief description of changes
Added Collector deprecation warning to v6 version branch

#### issues addressed
(https://github.com/archesproject/arches-docs/issues/284)

#### further comments
Discussed this with the GCI Arches team. The plan is to add this deprecation warning to the v6 branches, and remove all reference to Collector from v7 branches.

---

This box **must** be checked
- [X] the PR branch was originally made from the base branch

This box **should** be checked
- [X] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [X] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
