### PR TITLE
Removed references to the deprecated Collector

### DIFF
--- a/docs/administering/managing-permissions.txt
+++ b/docs/administering/managing-permissions.txt
@@ -77,10 +77,6 @@ a member of as many different groups as needed.
   :Use Case: Changing data stored in the system settings graph.
   :Access Privileges: Ability to access/edit data in Arches System Settings.
 
-:Mobile Project Administrator:
-  :Use Case: For creating, configuring, and removing mobile projects
-  :Access Privileges: Full access to the Arches Collector Manager.
-
 :Crowdsource Editor:
   :Use Case: Creation of provisional data from an untrusted source. Default group user is assigned to when first added to the system via e-mail sign-up.
   :Access Privileges: Add/edit/delete resources your own provisional data tiles

--- a/docs/deployment/serving-arches-with-apache.txt
+++ b/docs/deployment/serving-arches-with-apache.txt
@@ -102,7 +102,7 @@ will benefit your production installation.
             WSGIDaemonProcess arches python-path=/home/ubuntu/Projects/my_project
             WSGIScriptAlias / /home/ubuntu/Projects/my_project/my_project/wsgi.py process-group=arches
 
-            # Necessary to support Arches Collector
+            # May be necessary to support integration with possible 3rd party mobile apps
             WSGIPassAuthorization on
 
             ## Uncomment the ServerName directive and fill it with your domain

--- a/docs/developing/reference/api.txt
+++ b/docs/developing/reference/api.txt
@@ -96,7 +96,7 @@ If both a custom header and querystring with the same name are provided, then th
 Register an OAuth Application
 =============================
 
-To allow others to connect to your Arches instance, including Arches Collector users, you must create an OAuth client id and add it to your settings.
+To allow others to connect to your Arches instance, you must create an OAuth client id and add it to your settings.
 
 #. In a browser go to
 

--- a/docs/introduction/overview.txt
+++ b/docs/introduction/overview.txt
@@ -33,7 +33,7 @@ To promote consistent data creation, update, and indexing workflows, Arches impl
 
     v5.0  January, 2020: Technology upgrades (Python 3.7, Django 2.3, Postgres 12.0/PostGIS 3.0, Elasticsearch 7.4), Workflows, Task Manager
 
-    v4.4  February, 2019: Release of Arches Collector mobile data collection app
+    v4.4  February, 2019: Release of Collector (now deprecated with v7.0 and later) mobile data
 
     v4.0  July, 2017: Significant site redesign, addition of graph creation UI, system settings UI, internal tileserver (TileStache), updated dependencies (MapBox GL, ElasticSearch 5.2, Yarn)
 


### PR DESCRIPTION
### brief description of changes
Removed reference (except for a historical note) about Collector. The GCI Arches team requested this to avoid confusion about the status of Collector.

#### issues addressed
(https://github.com/archesproject/arches-docs/issues/284)

#### further comments
The v6 branches have a deprecation warning, the v7 branches (and with this PR the master branch) will have all reference to Collector purged.

---

This box **must** be checked
- [X] the PR branch was originally made from the base branch

This box **should** be checked
- [X] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [ ] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
