### PR TITLE
Updated Node and Yarn dependency and installation docs

### DIFF
--- a/docs/requirements-and-dependencies.txt
+++ b/docs/requirements-and-dependencies.txt
@@ -34,8 +34,8 @@ Arches requires the following software packages to be installed and available. U
 :GDAL >= 2.2.x: - **Windows** Use the `OSGeo4W installer <https://trac.osgeo.org/osgeo4w/>`_, and choose to install the GDAL package (you don't need QGIS or GRASS). After installation, add ``C:\OSGeo4W64\bin`` to your system's ``PATH`` environment variable.
 :Node.js 16.x (recommended): - Installation: https://nodejs.org/ (choose the installer appropriate to your operating system).
     - NOTE: Arches may not be compatible with later versions of Node.js (after 16) `(see discussion) <https://community.archesproject.org/t/newbie-v7-install-experience-some-hints-and-tips/1782>`_.
-:Yarn >= 1.22: - Installation: https://yarnpkg.com/getting-started/install
-    - NOTE: As described in the link above, you will install Yarn via the `Node.js <https://nodejs.org/>`_ package manager. Yarn installation via Node.js package management should be consistent across different operating systems.
+:Yarn >= 1.22, < 2: - Installation: https://yarnpkg.com/getting-started/install
+    - NOTE: As described in the link above, you will typically install Yarn via the `Node.js <https://nodejs.org/>`_ package manager. Yarn installation via Node.js package management should be consistent across different operating systems. One can also instal Yarn via `apt` on Linux operating systems.
 
 To support long-running task management, like large user downloads, you must install a Celery broker like RabbitMQ or Redis:
 

--- a/docs/requirements-and-dependencies.txt
+++ b/docs/requirements-and-dependencies.txt
@@ -34,8 +34,8 @@ Arches requires the following software packages to be installed and available. U
 :GDAL >= 2.2.x: - **Windows** Use the `OSGeo4W installer <https://trac.osgeo.org/osgeo4w/>`_, and choose to install the GDAL package (you don't need QGIS or GRASS). After installation, add ``C:\OSGeo4W64\bin`` to your system's ``PATH`` environment variable.
 :Node.js 16.x (recommended): - Installation: https://nodejs.org/ (choose the installer appropriate to your operating system).
     - NOTE: Arches may not be compatible with later versions of Node.js (after 16) `(see discussion) <https://community.archesproject.org/t/newbie-v7-install-experience-some-hints-and-tips/1782>`_.
-:Yarn >= 1.22, < 2: - Installation: https://yarnpkg.com/getting-started/install
-    - NOTE: As described in the link above, you will typically install Yarn via the `Node.js <https://nodejs.org/>`_ package manager. Yarn installation via Node.js package management should be consistent across different operating systems. One can also install Yarn via `apt` on Linux operating systems.
+:Yarn >= 1.22, < 2: - Recommended Installation: https://classic.yarnpkg.com/en/docs/install (One can also install Yarn via `apt` on Linux operating systems, `see example <https://github.com/archesproject/arches/blob/f06b838cf1be23471644f8528a630d65c8bff9a7/arches/install/ubuntu_setup.sh#L51>`_).
+    - NOTE: We are pointing to the "classic" yarn installer to avoid installation of more recent versions of yarn that are not compatible with Arches via the `Node.js` `package manager <https://yarnpkg.com/getting-started/install>`_.
 
 To support long-running task management, like large user downloads, you must install a Celery broker like RabbitMQ or Redis:
 

--- a/docs/requirements-and-dependencies.txt
+++ b/docs/requirements-and-dependencies.txt
@@ -25,15 +25,17 @@ Arches requires the following software packages to be installed and available. U
     - Python 3.7 and later comes with pip
     - **Windows** You must choose 32-bit or 64-bit Python based on your system architecture.
     - **macOS** This guide works well if you wish to install via `brew`: https://docs.python-guide.org/starting/install3/osx/
-:PostgreSQL 12 with PostGIS 3:
+:PostgreSQL >= 12 with PostGIS 3:
     - **macOS** Use `Postgres.app <http://postgresapp.com>`_.
     - **Windows** Use the `EnterpriseDB installers <https://www.postgresql.org/download/windows/>`_, and use Stack Builder (included) to get PostGIS. After installation, add the following to your system's ``PATH`` environment variable: ``C:\Program Files\PostgreSQL\12\bin``. Make sure you write down the password that you assign to the ``postgres`` user.
 :Elasticsearch 8: - Installers: https://www.elastic.co/downloads/past-releases/elasticsearch-8-5-1
     - Elasticsearch is integral to Arches and can be installed and configured many ways.
       For more information, see :ref:`Arches and Elasticsearch`.
 :GDAL >= 2.2.x: - **Windows** Use the `OSGeo4W installer <https://trac.osgeo.org/osgeo4w/>`_, and choose to install the GDAL package (you don't need QGIS or GRASS). After installation, add ``C:\OSGeo4W64\bin`` to your system's ``PATH`` environment variable.
-:Yarn: - Installation: https://yarnpkg.com/lang/en/docs/install
-    - **Windows** Use the .msi installer in the link above, but first install `Node.js <https://nodejs.org/>`_.
+:Node.js 16.x (recommended): - Installation: https://nodejs.org/ (choose the installer appropriate to your operating system).
+    - NOTE: Arches may not be compatible with later versions of Node.js (after 16) `(see discussion) <https://community.archesproject.org/t/newbie-v7-install-experience-some-hints-and-tips/1782>`_.
+:Yarn: - Installation: https://yarnpkg.com/getting-started/install
+    - NOTE: As described in the link above, you will install Yarn via the `Node.js <https://nodejs.org/>`_ package manager. Yarn installation via Node.js package management should be consistent across different operating systems.
 
 To support long-running task management, like large user downloads, you must install a Celery broker like RabbitMQ or Redis:
 

--- a/docs/requirements-and-dependencies.txt
+++ b/docs/requirements-and-dependencies.txt
@@ -34,7 +34,7 @@ Arches requires the following software packages to be installed and available. U
 :GDAL >= 2.2.x: - **Windows** Use the `OSGeo4W installer <https://trac.osgeo.org/osgeo4w/>`_, and choose to install the GDAL package (you don't need QGIS or GRASS). After installation, add ``C:\OSGeo4W64\bin`` to your system's ``PATH`` environment variable.
 :Node.js 16.x (recommended): - Installation: https://nodejs.org/ (choose the installer appropriate to your operating system).
     - NOTE: Arches may not be compatible with later versions of Node.js (after 16) `(see discussion) <https://community.archesproject.org/t/newbie-v7-install-experience-some-hints-and-tips/1782>`_.
-:Yarn: - Installation: https://yarnpkg.com/getting-started/install
+:Yarn >= 1.22: - Installation: https://yarnpkg.com/getting-started/install
     - NOTE: As described in the link above, you will install Yarn via the `Node.js <https://nodejs.org/>`_ package manager. Yarn installation via Node.js package management should be consistent across different operating systems.
 
 To support long-running task management, like large user downloads, you must install a Celery broker like RabbitMQ or Redis:

--- a/docs/requirements-and-dependencies.txt
+++ b/docs/requirements-and-dependencies.txt
@@ -35,7 +35,7 @@ Arches requires the following software packages to be installed and available. U
 :Node.js 16.x (recommended): - Installation: https://nodejs.org/ (choose the installer appropriate to your operating system).
     - NOTE: Arches may not be compatible with later versions of Node.js (after 16) `(see discussion) <https://community.archesproject.org/t/newbie-v7-install-experience-some-hints-and-tips/1782>`_.
 :Yarn >= 1.22, < 2: - Installation: https://yarnpkg.com/getting-started/install
-    - NOTE: As described in the link above, you will typically install Yarn via the `Node.js <https://nodejs.org/>`_ package manager. Yarn installation via Node.js package management should be consistent across different operating systems. One can also instal Yarn via `apt` on Linux operating systems.
+    - NOTE: As described in the link above, you will typically install Yarn via the `Node.js <https://nodejs.org/>`_ package manager. Yarn installation via Node.js package management should be consistent across different operating systems. One can also install Yarn via `apt` on Linux operating systems.
 
 To support long-running task management, like large user downloads, you must install a Celery broker like RabbitMQ or Redis:
 


### PR DESCRIPTION
### brief description of changes
There has been some forum discussion and an issue raised here about Node.js and Yarn dependencies. I consulted with @chiatt about this and he provided information about compatibility issues and recommended installation approaches.

#### issues addressed
(https://github.com/archesproject/arches-docs/issues/275)

#### further comments
We will revisit this with future versions of Arches that may use the npm package manager and / or more recent versions of yarn.

---

This box **must** be checked
- [X] the PR branch was originally made from the base branch

This box **should** be checked
- [X] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [X] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
