### PR TITLE
Api json 7 3

### DIFF
--- a/docs/api.txt
+++ b/docs/api.txt
@@ -206,12 +206,11 @@ OAuth 2.0 is a simple and secure authentication mechanism. It allows application
         {"error": "invalid_client"}
 
 
-General Expectations Requesting JSON
+General Expectations Requesting JSON-LD
 =========
 
 .. note::
-    **Include a format parameter**
-
+    
     If you use the API to make a `GET` request for a resource, Arches will default to the `json-ld` representation
     format unless you specify otherwise using the `format` parameter in your request URL. Be aware that the
     `json-ld` format requires use of one or more ontologies for your resource model. Requests for resource

--- a/docs/api.txt
+++ b/docs/api.txt
@@ -212,9 +212,11 @@ General Expectations Requesting JSON
 .. note::
     **Include a format parameter**
 
-    In general, when making an API request to `GET` representations of data (in Arches JSON or JSON-LD), 
-    you *MUST* include the parameter `format` with an integer value in your request URL. Requests 
-    without this parameter may fail with a server-side (500) error. For example,
+    If you use the API to make a `GET` request for a resource, Arches will default to the `json-ld` representation
+    format unless you specify otherwise using the `format` parameter in your request URL. Be aware that the
+    `json-ld` format requires use of one or more ontologies for your resource model. Requests for resource
+    instances without ontology modeling may fail with a server-side (500) error. If you are not using an ontology
+    you need to request data in the `json` or `arches-json` format. For example, without an ontology, 
     `http://somehost.com/resources/{uuid:resource id}?format=json&indent=2` will
     work while `http://somehost.com/resources/{uuid:resource id}` will fail. 
     `(See discussion) <https://community.archesproject.org/t/typeerror-on-resources-resource-id-endpoint/1855/3>`_

--- a/docs/api.txt
+++ b/docs/api.txt
@@ -210,12 +210,14 @@ General Expectations Requesting JSON
 =========
 
 .. note::
-    **Include an indent parameter**
+    **Include a format parameter**
 
-    In general, when making a request to `GET` JSON representations of data, you *MUST* include the parameter
-    `indent` with an integer value in your request URL. Requests without this parameter may fail with a
-    server-side (500) error. For example, `http://somehost.com/resources/{uuid:resource id}?format=json&indent=2` will
-    work while `http://somehost.com/resources/{uuid:resource id}?format=json` will fail. `(See discussion) <https://community.archesproject.org/t/typeerror-on-resources-resource-id-endpoint/1855/3>`_
+    In general, when making an API request to `GET` representations of data (in Arches JSON or JSON-LD), 
+    you *MUST* include the parameter `format` with an integer value in your request URL. Requests 
+    without this parameter may fail with a server-side (500) error. For example,
+    `http://somehost.com/resources/{uuid:resource id}?format=json&indent=2` will
+    work while `http://somehost.com/resources/{uuid:resource id}` will fail. 
+    `(See discussion) <https://community.archesproject.org/t/typeerror-on-resources-resource-id-endpoint/1855/3>`_
 
 
 Concepts

--- a/docs/api.txt
+++ b/docs/api.txt
@@ -163,6 +163,9 @@ OAuth 2.0 is a simple and secure authentication mechanism. It allows application
 
         curl -X POST http://localhost:8000/o/token/ -d "username=admin&password=admin&grant_type=password&client_id=onFiQSbPfgZpsUcl2fBvaaEHA58MKHavl3iuSaRf"
 
+    .. note:: In this example, we're making a POST request over HTTP, not HTTPS.
+        You should only use HTTP this for testing purposes. In production, all Web requests should be made over HTTPS, otherwise
+        you may reveal sensitive information, such as passwords.
 
     **Example response**:
 
@@ -201,6 +204,18 @@ OAuth 2.0 is a simple and secure authentication mechanism. It allows application
         Content-Type: application/json
 
         {"error": "invalid_client"}
+
+
+General Expectations Requesting JSON
+=========
+
+.. note::
+    **Include an indent parameter**
+
+    In general, when making a request to `GET` JSON representations of data, you *MUST* include the parameter
+    `indent` with an integer value in your request URL. Requests without this parameter may fail with a
+    server-side (500) error. For example, `http://somehost.com/resources/{uuid:resource id}?format=json&indent=2` will
+    work while `http://somehost.com/resources/{uuid:resource id}?format=json` will fail. `(See discussion) <https://community.archesproject.org/t/typeerror-on-resources-resource-id-endpoint/1855/3>`_
 
 
 Concepts


### PR DESCRIPTION
### brief description of changes
Updated API documentation to note that the default JSON-LD format representations will fail if no ontology is in use.

#### issues addressed
(https://github.com/archesproject/arches-docs/issues/319)

#### further comments
I'm not sure exactly where to put this new advice. It seems to be OK here, but I'm open to suggestions:
https://arches.readthedocs.io/en/api_json_7_3/api/#general-expectations-requesting-json-ld

---

This box **must** be checked
- [X] the PR branch was originally made from the base branch

This box **should** be checked
- [X] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [X] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
