### PR TITLE
Celery 7 3

### DIFF
--- a/docs/setting-up-supervisord-for-celery.txt
+++ b/docs/setting-up-supervisord-for-celery.txt
@@ -11,7 +11,7 @@ queue so that requests to the Arches application do not lead to timeout or other
 This documentation discusses how to enable Celery task management using Supervisord (http://supervisord.org/). Essentially, Supervisord automatically monitors and controls Celery workers, checking to make sure they are operating, and restarting them if they fail.
 
 
-When Do I Need Supervisor and Celery?
+When Do I Need Supervisord and Celery?
 =====================================
 Arches *does not require* Supervisord and Celery to run in "production" mode (with ``DEBUG=False`` in `settings.py`). Arches instances managing smaller amounts of data may not need Supervisord and Celery. The deployment scenarios where you *should* consider using Supervisord and Celery include:
 

--- a/docs/setting-up-supervisord-for-celery.txt
+++ b/docs/setting-up-supervisord-for-celery.txt
@@ -96,7 +96,7 @@ Known Issue with Arches Celery Configurations and Celery Beat:
       ``/absolute/path/to/virtualenv/bin/celery -A my_proj_name.celery beat``
       ``--schedule=/tmp/celerybeat-schedule --loglevel=INFO --pidfile=/tmp/celerybeat.pid``
 
-    After fixing the command syntax, the celery worker should function. However, you may still have trouble getting celery beat to work (https://github.com/archesproject/arches/issues/9243). Celery beat schedules periodic tasks (much like a `crontab` in a Linux operating system) using a Python implementation. In many cases, you may not need celery beat and Arches will function without problems. However, if you have workarounds or fixes, please let us know!
+    After fixing the command syntax, the celery worker should function. However, you may still have trouble getting celery beat to work (https://github.com/archesproject/arches/issues/9243). Celery beat schedules periodic tasks (much like a `crontab` in a Linux operating system) using a Python implementation. In many cases, Arches will function without (evident) problems even if celery beat does not work. However, if you have workarounds or fixes, please let us know!
 
 
 More information:

--- a/docs/setting-up-supervisord-for-celery.txt
+++ b/docs/setting-up-supervisord-for-celery.txt
@@ -93,7 +93,8 @@ Known Issue with Arches Celery Configurations and Celery Beat:
       ``/absolute/path/to/virtualenv/bin/celery -A my_proj_name.celery worker --loglevel=INFO``
 
     * The corrected syntax (celery >= v5x) for the command at the top of `my_proj_name-celerybeat.conf` looks like (all in one line):
-      ``/absolute/path/to/virtualenv/bin/celery -A my_proj_name.celery beat --schedule=/tmp/celerybeat-schedule`` ``--loglevel=INFO --pidfile=/tmp/celerybeat.pid``
+      ``/absolute/path/to/virtualenv/bin/celery -A my_proj_name.celery beat``
+      ``--schedule=/tmp/celerybeat-schedule --loglevel=INFO --pidfile=/tmp/celerybeat.pid``
 
     After fixing the command syntax, the celery worker should function. However, you may still have trouble getting celery beat to work (https://github.com/archesproject/arches/issues/9243). Celery beat schedules periodic tasks (much like a `crontab` in a Linux operating system) using a Python implementation. In many cases, you may not need celery beat and Arches will function without problems. However, if you have workarounds or fixes, please let us know!
 

--- a/docs/setting-up-supervisord-for-celery.txt
+++ b/docs/setting-up-supervisord-for-celery.txt
@@ -25,7 +25,7 @@ Supervisor and Celery Installation and Configuration
 The following is a guide **for a linux-based** OS; be advised you can change any of the file names, destinations, or permissions to suit your needs.
 
 
-1. Supervisor can be installed using ``pip``: ``pip install supervisor``.
+1. Supervisor can be installed using in your Arches virtual environment with ``pip``: ``pip install supervisor``.
 
 
 2. In the core arches repo, in `arches/install/supervisor_celery_setup <https://github.com/archesproject/arches/tree/master/arches/install/supervisor_celery_setup>`_ there exist example files for supervisor, celeryd, and celerybeat. We recommend copying them into the following directory structure:
@@ -61,7 +61,7 @@ The following is a guide **for a linux-based** OS; be advised you can change any
 6. Download and install RabbitMQ: https://www.rabbitmq.com/download.html
 
 
-7. Once successfully installed (and verified that it has been added to your PATH), start running it with the command ``rabbitmq-server``. For a convenient option, this can be run in a screen. Note that rabbitmq should be run prior to running supervisord.
+7. Once successfully installed (and verified that it has been added to your PATH), start running it with the command ``rabbitmq-server``. For a convenient option, this can be run in a screen. Note that rabbitmq should be run prior to running supervisord. If you choose, you can use Redis as a "broker" instead of RabbitMQ (see below).
 
 
 8. Run ``supervisord -c /etc/supervisor/my_proj_name-supervisord.conf`` to start the supervisord which will start celery workers for your tasks.
@@ -75,18 +75,31 @@ The following is a guide **for a linux-based** OS; be advised you can change any
     d. To shut down supervisord (and the celery processes it controls): ``unlink /tmp/supervisor.sock``
 
 
-Known Issue with Arches Celery Configurations Celerybeat:
-    The default configuration files in the `conf.d` directory discussed above have need updating. Version 5 and later of celery has a revised order of arguments in using celery commands (see: https://github.com/archesproject/arches/issues/9202).
+Setting up Redis Instead of RabbitMQ
+    Redis can serve as an alternative to RabbitMQ, but it lacks official Windows support. If you are not deploying Arches on Windows, you can use Redis as follows:
 
-    * The corrected syntax (celery >=5x) for the command at the top of `my_proj_name-celeryd.conf` looks like:
-      ``/usr/local/bin/celery -A my_proj_name.celery worker --loglevel=INFO``
+    1. Follow the above directions (steps 1 to 5) for setting up supervisored, celery, and their configurations.
+    2. Install Redis (see: https://redis.io/docs/getting-started/)
+    3. Install the Python interface to Redis into your Arches virtual environment with ``pip``: ``pip install redis``
+    4. Configure the `CELERY_BROKER_URL` (in `settings.py` or overwritten in `settings_local.py`): ``CELERY_BROKER_URL = "redis://@localhost:6379/0"``
+    5. Activate Redis: ``redis-server``
+    6. Run ``supervisord -c /etc/supervisor/my_proj_name-supervisord.conf`` to start the supervisord and celery workers
+    7. Start Arches
 
-    * The corrected syntax (celery >=5x) for the command at the top of `my_proj_name-celerybeat.conf` looks like:
-      ``/usr/local/bin/celery -A my_proj_name.celery beat --schedule=/tmp/celerybeat-schedule --loglevel=INFO --pidfile=/tmp/celerybeat.pid``
+Known Issue with Arches Celery Configurations and Celery Beat:
+    The default configuration files in the `conf.d` directory discussed above need updating. Version 5 and later of celery has a revised order of arguments in using celery commands (see: https://github.com/archesproject/arches/issues/9202).
 
-    After fixing the command syntax, the celery worker will likely function. However, you may still have trouble getting celery beat to work (https://github.com/archesproject/arches/issues/9243). Celery beat schedules periodic tasks (much like a `crontab` in a Linux operating system) using a Python implementation. In many cases, you may not need celery beat and may notice no trouble. However, if you have workarounds or fixes, please let us know!
+    * The corrected syntax (celery >= v5x) for the command at the top of `my_proj_name-celeryd.conf` looks like:
+      ``/absolute/path/to/virtualenv/bin/celery -A my_proj_name.celery worker --loglevel=INFO``
+
+    * The corrected syntax (celery >= v5x) for the command at the top of `my_proj_name-celerybeat.conf` looks like (all in one line):
+      ``/absolute/path/to/virtualenv/bin/celery -A my_proj_name.celery beat --schedule=/tmp/celerybeat-schedule`` ``--loglevel=INFO --pidfile=/tmp/celerybeat.pid``
+
+    After fixing the command syntax, the celery worker should function. However, you may still have trouble getting celery beat to work (https://github.com/archesproject/arches/issues/9243). Celery beat schedules periodic tasks (much like a `crontab` in a Linux operating system) using a Python implementation. In many cases, you may not need celery beat and Arches will function without problems. However, if you have workarounds or fixes, please let us know!
 
 
 More information:
  * Supervisord documentation: http://supervisord.org/
  * Celery sample files for supervisord: https://github.com/celery/celery/tree/master/extra/supervisord
+ * Redis: https://redis.io/
+ * Redis (Python interface): https://pypi.org/project/redis/

--- a/docs/setting-up-supervisord-for-celery.txt
+++ b/docs/setting-up-supervisord-for-celery.txt
@@ -4,7 +4,25 @@
 Setting up Supervisord for Celery
 #################################
 
-When implementing celery on a production instance it may be preferable to delegate supervisord to manage celery workers and celery beats. The following is a guide **for a linux-based** OS; be advised you can change any of the file names, destinations, or permissions to suit your needs.
+Arches uses Celery (https://docs.celeryq.dev/en/stable/getting-started/introduction.html), a Python framework for setting up and managing task queues. Using Celery,
+Arches can delegate certain tasks with long execution times to separate processes. In a production deployment, this can enable Arches to delegate big jobs to a
+queue so that requests to the Arches application do not lead to timeout or other errors.
+
+This documentation discusses how to enable Celery task management using Supervisord (http://supervisord.org/). Essentially, Supervisord automatically monitors and controls Celery workers, checking to make sure they are operating, and restarting them if they fail.
+
+
+When Do I Need Supervisor and Celery?
+=====================================
+Arches *does not require* Supervisord and Celery to run in "production" mode (with ``DEBUG=False`` in `settings.py`). Arches instances managing smaller amounts of data may not need Supervisord and Celery. The deployment scenarios where you *should* consider using Supervisord and Celery include:
+
+ * Supervisord and Celery will be required if you want to enable export / bulk download of more than 2000 resource instances.
+ * Supervisord and Celery will be required to enable the Bulk Data Manager plugin to function. (Note: by default, Arches installs this plugin in hidden state.)
+
+
+
+Supervisor and Celery Installation and Configuration
+====================================================
+The following is a guide **for a linux-based** OS; be advised you can change any of the file names, destinations, or permissions to suit your needs.
 
 
 1. Supervisor can be installed using ``pip``: ``pip install supervisor``.
@@ -49,7 +67,24 @@ When implementing celery on a production instance it may be preferable to delega
 8. Run ``supervisord -c /etc/supervisor/my_proj_name-supervisord.conf`` to start the supervisord which will start celery workers for your tasks.
 
 
-9. To stop your supervisord process, run ``unlink /tmp/supervisor.sock``.
+9. To check and stop your supervisord process, please review the following:
+
+    a. To check on the status of celery (workers): ``supervisorctl -c /etc/supervisor/my_project-supervisor.conf status``
+    b. To restart celery workers: ``supervisorctl -c /etc/supervisor/my_project-supervisor.conf restart celery``
+    c. To stop celery workers: ``supervisorctl -c /etc/supervisor/my_project-supervisor.conf stop celery``
+    d. To shut down supervisord (and the celery processes it controls): ``unlink /tmp/supervisor.sock``
+
+
+Known Issue with Arches Celery Configurations Celerybeat:
+    The default configuration files in the `conf.d` directory discussed above have need updating. Version 5 and later of celery has a revised order of arguments in using celery commands (see: https://github.com/archesproject/arches/issues/9202).
+
+    * The corrected syntax (celery >=5x) for the command at the top of `my_proj_name-celeryd.conf` looks like:
+      ``/usr/local/bin/celery -A my_proj_name.celery worker --loglevel=INFO``
+
+    * The corrected syntax (celery >=5x) for the command at the top of `my_proj_name-celerybeat.conf` looks like:
+      ``/usr/local/bin/celery -A my_proj_name.celery beat --schedule=/tmp/celerybeat-schedule --loglevel=INFO --pidfile=/tmp/celerybeat.pid``
+
+    After fixing the command syntax, the celery worker will likely function. However, you may still have trouble getting celery beat to work (https://github.com/archesproject/arches/issues/9243). Celery beat schedules periodic tasks (much like a `crontab` in a Linux operating system) using a Python implementation. In many cases, you may not need celery beat and may notice no trouble. However, if you have workarounds or fixes, please let us know!
 
 
 More information:

--- a/docs/setting-up-supervisord-for-celery.txt
+++ b/docs/setting-up-supervisord-for-celery.txt
@@ -78,7 +78,7 @@ The following is a guide **for a linux-based** OS; be advised you can change any
 Setting up Redis Instead of RabbitMQ
     Redis can serve as an alternative to RabbitMQ, but it lacks official Windows support. If you are not deploying Arches on Windows, you can use Redis as follows:
 
-    1. Follow the above directions (steps 1 to 5) for setting up supervisored, celery, and their configurations.
+    1. Follow the above directions (steps 1 to 5) for setting up supervisored, celery, and their configurations
     2. Install Redis (see: https://redis.io/docs/getting-started/)
     3. Install the Python interface to Redis into your Arches virtual environment with ``pip``: ``pip install redis``
     4. Configure the `CELERY_BROKER_URL` (in `settings.py` or overwritten in `settings_local.py`): ``CELERY_BROKER_URL = "redis://@localhost:6379/0"``


### PR DESCRIPTION
### brief description of changes
This updates supervisord and celery documentation to explain more about when they may be required, provide some options for using Redis, and document a workaround for some config syntax that needs updating. It also includes some of admin commands suggested by @mradamcox.

Demo here: https://arches.readthedocs.io/en/celery_7_3/setting-up-supervisord-for-celery/

#### issues addressed
(https://github.com/archesproject/arches-docs/issues/310)

#### further comments
ReadTheDocs temporarily relaxed PDF documentation build checking, so I'd like to get this in ASAP before they make builds harder again.

I'll be adding some more production config documentation about Nginx and Docker also.

---

This box **must** be checked
- [x] the PR branch was originally made from the base branch

This box **should** be checked
- [x] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [x] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
