### PR TITLE
Added subsection for multiple language CSV column names

### DIFF
--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -1,0 +1,9 @@
+{% extends '!footer.html' %} {% block extrafooter %} {{super}}
+<br/>
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">
+    <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" />
+</a>
+<br />This documentation is licensed under a
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">
+    Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ release = '7.3.0'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -121,7 +121,7 @@ todo_include_todos = True
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+# html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
@@ -171,7 +171,7 @@ html_extra_path = ['robots.txt',]
 #html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+# html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.

--- a/docs/localizing-arches.txt
+++ b/docs/localizing-arches.txt
@@ -147,7 +147,7 @@ CSV Column (Field) Names Indicating Languages
 To import a CSV file with multi-lingual business data, the field names (column names) need to end with
 applicable language codes (expressed with parentheses). For example, if you wish to import
 US English, Chinese, Arabic, and Hebrew business data for a string node called *label*,
-you will your CSV file needs to include field names (column names) as follows:
+your CSV file needs to include field names (column names) as follows:
 
 +---------------+------------+------------+------------+
 | label (en-US) | label (zh) | label (ar) | label (he) |

--- a/docs/localizing-arches.txt
+++ b/docs/localizing-arches.txt
@@ -40,7 +40,7 @@ If you want to support localization in your Arches instance, you'll first need t
     # {langcode}-{regioncode} eg: en, en-gb ....
     # a list of language codes can be found here http://www.i18nguy.com/unicode/language-identifiers.html
     LANGUAGE_CODE = "en"
-    # list of languages to display in the language switcher, 
+    # list of languages to display in the language switcher,
     # if left empty or with a single entry then the switch won't be displayed
     # language codes need to be all lower case with the form:
     # {langcode}-{regioncode} eg: en, en-gb ....
@@ -59,7 +59,7 @@ If you want to support localization in your Arches instance, you'll first need t
 .. code-block:: python
 
     from django.conf.urls.i18n import i18n_patterns
-    
+
 5. Finally add the following code to the end of your urls.py file:
 
 .. code-block:: python
@@ -99,16 +99,16 @@ Setting up Localized Languages for Business Data
 ************************************************
 
 By default, every language from the LANGUAGES array in settings.py is available for business data entry.
-To add additional languages for business data entry only, you can do the following. 
+To add additional languages for business data entry only, you can do the following.
 
 1.  Access the admin page (``http://localhost:8000/admin/``)
 2.  Choose the "Languages" table.  (``http://localhost:8000/models/language``)
 3.  Select "Add Language"
 4.  Fill in information on new language, including a default direction.
 
-Repeat this process for all new languages you wish to add. 
+Repeat this process for all new languages you wish to add.
 
-Additionally, remove any languages you do not plan on using.  
+Additionally, remove any languages you do not plan on using.
 
 Once this is complete, text widgets should be able to write data in the desired languages.
 
@@ -116,9 +116,9 @@ Once this is complete, text widgets should be able to write data in the desired 
 RDF Imports and Exports
 ***********************
 
-Business data can be exported in RDF format. The directionality of the string data will be lost as 
-the RDF specification does not include directionality. There is an 
-`active attempt <https://w3c.github.io/rdf-dir-literal/>`_ to include direction within the 
+Business data can be exported in RDF format. The directionality of the string data will be lost as
+the RDF specification does not include directionality. There is an
+`active attempt <https://w3c.github.io/rdf-dir-literal/>`_ to include direction within the
 RDF specification.
 
 ***********************
@@ -126,16 +126,29 @@ CSV Exports and Imports
 ***********************
 
 It is possible to import and export localized business data through CSV format. There is a ``--language``
-switch that will limit the languages that will be exported (all languages are exported by default). 
-However, if attempting to re-import a limited subset of languages through the csv importer, entire 
-string objects will be overwritten by the subset. For example, if a string node has values for 
+switch that will limit the languages that will be exported (all languages are exported by default).
+However, if attempting to re-import a limited subset of languages through the csv importer, entire
+string objects will be overwritten by the subset. For example, if a string node has values for
 English, Spanish, and French, the subset of languages can be limited by specifying
 
 .. code-block:: bash
 
     --languages en,es
 
-If attempting to import the resulting csv, any values that were pre-existing for French would be 
+If attempting to import the resulting csv, any values that were pre-existing for French would be
 overwritten in "overwrite" mode or added as a separate tile in "append" mode. There is currently
 no way to merge these values. If the intention is to re-import the csv values later, export all
 languages.
+
+
+CSV Column (Field) Names Indicating Languages
+----------------------------------------------
+
+To import a CSV file with multi-lingual business data, the field names (column names) need to end with
+applicable language codes (expressed with parentheses). For example, if you wish to import
+US English, Chinese, Arabic, and Hebrew business data for a string node called *label*,
+you will your CSV file needs to include field names (column names) as follows:
+
++---------------+------------+------------+------------+
+| label (en-US) | label (zh) | label (ar) | label (he) |
++---------------+------------+------------+------------+


### PR DESCRIPTION
### brief description of changes
Responds to a gap in documentation identified by @chiatt where we lacked instruction on how to structure CSV files to import business data that contain string nodes in multiple languages.

#### issues addressed
https://github.com/archesproject/arches/issues/9288#issuecomment-1513028942

#### further comments
The updated section is demoed here: https://arches.readthedocs.io/en/csv_int_7_3/localizing-arches/#csv-column-field-names-indicating-languages

Once approved, I'll update all version 7 branches to include this update.
---

This box **must** be checked
- [x] the PR branch was originally made from the base branch

This box **should** be checked
- [x] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [x] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
