### PR TITLE
Added CC-BY-SA license

### DIFF
--- a/docs/_templates/license.html
+++ b/docs/_templates/license.html
@@ -1,0 +1,6 @@
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">
+    <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" />
+</a>
+<br />This documentation is licensed under a
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">
+    Creative Commons Attribution-ShareAlike 4.0 International License</a>.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -122,6 +122,7 @@ html_theme = "pydata_sphinx_theme"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
+  "footer_items": ["copyright", "sphinx-version", "license",],
   "github_url": "https://github.com/archesproject/arches-docs",
   "header_links_before_dropdown": 4,
   "show_toc_level": 1,


### PR DESCRIPTION
### brief description of changes
With the approval of the GCI staff, I'm adding a Creative Commons Attribution Sharealike license to the documentation. This clarifies permissions and expectations for use and adaptations of the documentation. It aligns with the general spirit of the open source software license used for the Arches software application.

#### issues addressed
No public issue. Prioritized as an item in discussions with the GCI staff.

#### further comments
I will make similar changes to other branch versions of the documentation.

---

This box **must** be checked
- [X] the PR branch was originally made from the base branch

This box **should** be checked
- [X] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [X] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
