### PR TITLE
Search 7 4

### DIFF
--- a/docs/user-guide/searching.txt
+++ b/docs/user-guide/searching.txt
@@ -33,6 +33,11 @@ The Arches search feature supports a number of operators that you can use to fin
 In all the examples above we quote the search string for clarity. In the Arches application you wouldn’t need to put your search terms inside quotes.
 
 
+Escaping search operator characters
+-----------------------------------
+Arches version 7.4 introduced features that allow users to use backslashes ("\\") to escape special characters used as search operators. For example, if one wanted to do a search for the string “sheep?”, where the retrieved text needs to include the question-mark "?" character, one would need to escape the "?" character so that it is **NOT** interpreted as a **Wildcard** search operator (see above). The string "sheep\\?" escapes the "?" character and would search for the string “sheep?”.
+
+
 Advanced Search
 ---------------
 Arches also has "Advanced Search" options that enable users to search with specific branches to find resource instances. This adds much more precision to a search. For example, if you have resource instances described by both a "Color" branch and a "Material" branch a simple search for the term “gold” may return some unwanted results. The Advanced Search allows you to specify that you want to search within the "Material" branch, so a search for the term “gold” will return resource instances described by the material "gold", not just the color "gold".


### PR DESCRIPTION
### brief description of changes
Updates the user guide for search to discuss escaping characters used as search operators

#### issues addressed
Adds documentation to the updates made with this PR: https://github.com/archesproject/arches/pull/9574

#### further comments
The updated documentation can be (temporarily) reviewed here:  https://arches.readthedocs.io/en/search_7_4/user-guide/searching/#escaping-search-operator-characters

---

This box **must** be checked
- [x] the PR branch was originally made from the base branch

This box **should** be checked
- [x] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [ ] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
