### PR TITLE
Update installation docs with typo and consistency fixes

### DIFF
--- a/docs/configuring/settings-beyond-the-ui.txt
+++ b/docs/configuring/settings-beyond-the-ui.txt
@@ -88,7 +88,7 @@ To modify the list of **required special characters**, simply edit the list of c
 
 To change the **minimum length of a password**, change the `min_length`:code: property in the `MinLengthValidator`:code: validator.
 
-Advanced users can override or add new validators by creating their own validation classes as explained in `Django's password validation documentation <https://docs.djangoproject.com/en/1.11/topics/auth/passwords/#module-django.contrib.auth.password_validation/>`_.
+Advanced users can override or add new validators by creating their own validation classes as explained in `Django's password validation documentation <https://docs.djangoproject.com/en/stable/topics/auth/passwords/#module-django.contrib.auth.password_validation/>`_.
 
 Time Wheel Configuration
 ------------------------
@@ -137,7 +137,7 @@ If you have Memcached running at the following location `127.0.0.1:11211` then t
         }
     }
 
-This will cache the time wheel to your project's directory. There are other ways to define your cache that you may want to use. You can read more about those options in `Django's cache documentation <https://docs.djangoproject.com/en/1.11/topics/cache/>`_.
+This will cache the time wheel to your project's directory. There are other ways to define your cache that you may want to use. You can read more about those options in `Django's cache documentation <https://docs.djangoproject.com/en/stable/topics/cache/>`_.
 
 By default the time wheel will only be cached for 'anonymous' user for 24 hours. To add other users or to change the cache duration, you will need to modify this setting::
 
@@ -170,7 +170,7 @@ To enable users to sign up through the Arches UI, you will have to add the follo
     EMAIL_HOST_PASSWORD = 'xxxxxxx'
     EMAIL_PORT = 587
 
-Update the EMAIL_HOST_USER and EMAIL_HOST_PASSWORD with the correct email credentials and save the file. It is possible that this may not be enough to support your production of Arches. In that case, there's more information on setting up an email backend on the `Django site <https://docs.djangoproject.com/en/1.11/topics/email/#smtp-backend>`_.
+Update the EMAIL_HOST_USER and EMAIL_HOST_PASSWORD with the correct email credentials and save the file. It is possible that this may not be enough to support your production of Arches. In that case, there's more information on setting up an email backend on the `Django site <https://docs.djangoproject.com/en/stable/topics/email/#smtp-backend>`_.
 
 To configure what group new users are put into, add the following lines of code to your project's settings.py::
 

--- a/docs/deployment/implementing-ssl.txt
+++ b/docs/deployment/implementing-ssl.txt
@@ -61,7 +61,7 @@ You can transfer all the configuration related to arches to the new virtual host
 .. code-block::
 
     ServerName yourDomainName
-    LoadModule wsgi_module "/home/ubuntu/Projects/ENV/lib/python3.7/site-packages/mod_wsgi/server/mod_wsgi-py37.cpython-37m-x86_64-linux-gnu.so"
+    LoadModule wsgi_module "/home/ubuntu/Projects/ENV/lib/python3.8/site-packages/mod_wsgi/server/mod_wsgi-py37.cpython-37m-x86_64-linux-gnu.so"
     WSGIPythonHome "/home/ubuntu/Projects/ENV"
     <VirtualHost *:80>
         ServerName yourDomainName

--- a/docs/deployment/serving-arches-with-apache-nginx.txt
+++ b/docs/deployment/serving-arches-with-apache-nginx.txt
@@ -4,7 +4,7 @@ Serving Arches with Apache or Nginx
 
 .. sidebar:: Further Reference
 
-    + `Django Documentation <https://docs.djangoproject.com/en/3.2/howto/deployment/wsgi/modwsgi/#how-to-use-django-with-apache-and-mod-wsgi>`_
+    + `Django Documentation <https://docs.djangoproject.com/en/stable/howto/deployment/wsgi/modwsgi/#how-to-use-django-with-apache-and-mod-wsgi>`_
 
 During development, it's easiest to use the Django webserver to view your Arches installation. However, once you are ready to put the project into production, you'll have to use a more efficient, robust, and secure webserver like Apache or Nginx.
 

--- a/docs/deployment/serving-arches-with-apache-nginx.txt
+++ b/docs/deployment/serving-arches-with-apache-nginx.txt
@@ -62,7 +62,7 @@ will benefit your production installation.
 
     .. code-block:: bash
 
-        LoadModule wsgi_module "<your venv path>/lib/python3.7/site-packages/mod_wsgi/server/mod_wsgi-py37.cpython-37m-x86_64-linux-gnu.so"
+        LoadModule wsgi_module "<your venv path>/lib/python3.8/site-packages/mod_wsgi/server/mod_wsgi-py37.cpython-37m-x86_64-linux-gnu.so"
         WSGIPythonHome "<your venv path>"
 
     Copy these two lines, you will use them in step 3.
@@ -95,7 +95,7 @@ will benefit your production installation.
 
         # If you have mod_wsgi installed in your python virtual environment, paste the text generated
         # by 'mod_wsgi-express module-config' here, *before* the VirtualHost is defined.
-        LoadModule wsgi_module "/home/ubuntu/Projects/ENV/lib/python3.7/site-packages/mod_wsgi/server/mod_wsgi-py37.cpython-37m-x86_64-linux-gnu.so"
+        LoadModule wsgi_module "/home/ubuntu/Projects/ENV/lib/python3.8/site-packages/mod_wsgi/server/mod_wsgi-py37.cpython-37m-x86_64-linux-gnu.so"
         WSGIPythonHome "/home/ubuntu/Projects/ENV"
 
         <VirtualHost *:80>

--- a/docs/developing/advanced/localizing-arches.txt
+++ b/docs/developing/advanced/localizing-arches.txt
@@ -71,7 +71,7 @@ If you want to support localization in your Arches instance, you'll first need t
 
 Once the system is prepared for localization, the next steps involve generating a Django message file or .po file which will contain all available translation strings in Arches and how they should be translated in any given language.
 
-For more information, see `Localization: how to create language files <https://docs.djangoproject.com/en/4.0/topics/i18n/translation/#localization-how-to-create-language-files>`_ in the Django documentation.
+For more information, see `Localization: how to create language files <https://docs.djangoproject.com/en/stable/topics/i18n/translation/#localization-how-to-create-language-files>`_ in the Django documentation.
 
 There are some example commands to make and load PO files in the core arches settings file that can be found `here <https://github.com/archesproject/arches/blob/dev/7.0.x/arches/settings.py#L193>`_. If loading a new PO file, simply replace the existing po file and run compilemessages.
 

--- a/docs/developing/extending/create-html-export-templates.txt
+++ b/docs/developing/extending/create-html-export-templates.txt
@@ -22,7 +22,7 @@ The templates must have the name format of ``<graph id>.htm``, with the <graph i
 Templating Language
 ===================
 
-The templates are using the native Django templating engine, information of which can be found here: https://docs.djangoproject.com/en/3.2/ref/templates/language/
+The templates are using the native Django templating engine, information of which can be found here: https://docs.djangoproject.com/en/stable/ref/templates/language/
 
 
 Resources Context Data

--- a/docs/developing/getting-started/creating-a-development-environment.txt
+++ b/docs/developing/getting-started/creating-a-development-environment.txt
@@ -61,7 +61,7 @@ Core Arches
     
     .. note::
 
-        If you later switch to a new git branch, you may need to rerun ``pip install -r requirements.txt``, as the Python dependencies do change over the course of Arches releases.
+        If you later switch to a new git branch, you may need to rerun ``pip install -r arches/install/requirements.txt``, as the Python dependencies do change over the course of Arches releases.
 
 The Project
 -----------

--- a/docs/developing/getting-started/creating-a-development-environment.txt
+++ b/docs/developing/getting-started/creating-a-development-environment.txt
@@ -6,7 +6,7 @@ The following is our recommedation for creating an Arches environment that works
 
 **Runtime Content**
 
-+ ``ENV/`` - A Python 3.7+ virtual environment (you can name this whatever you want).
++ ``ENV/`` - A Python 3.8+ virtual environment (you can name this whatever you want).
 
 + ``arches/`` - The local clone of your fork of the `archesproject/arches <https://github.com/archesproject/arches>`_ repo, this part of the code is often referred to as "core Arches."
 
@@ -28,7 +28,7 @@ Core Arches
 
         You may also be planning to use externally hosted components, like a remote Postgres/PostGIS or Elasticsearch installation. In that case make sure you have the connection information handy, you will need it in a later step.
 
-#. :ref:`Create a new Python 3.7+ virtual environment <Create a Virtual Environment>`.
+#. :ref:`Create a new Python 3.8+ virtual environment <Create a Virtual Environment>`.
 
 #. Clone the core Arches repo
 

--- a/docs/developing/getting-started/creating-a-development-environment.txt
+++ b/docs/developing/getting-started/creating-a-development-environment.txt
@@ -124,7 +124,7 @@ and then in your ``urls.py``, change
 .. code-block:: python
 
     urlpatterns = [
-        url(r'^', include('arches.urls')),
+        path("", include("arches.urls")),
     ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 to
@@ -135,8 +135,8 @@ to
 
     urlpatterns = [
         # match and return your custom view before the default Arches url can get matched.
-        url(r"^user$", MyUserManagerView.as_view(), name="user_profile_manager"),
-        url(r'^', include('arches.urls')),
+        path("user/", MyUserManagerView.as_view(), name="user_profile_manager"),
+        path("", include("arches.urls")),
     ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 which will cause /user to match your new view before the core Arches /user url is found. Thus, going to ``localhost:8000/user`` will still return the default Arches profile manager page, but it has been passed through your class. You can now add a ``get()`` method to your class and it will be called to return the view instead of ``arches.app.views.user.UserManagerView().get()``.

--- a/docs/developing/reference/command-line-reference.txt
+++ b/docs/developing/reference/command-line-reference.txt
@@ -448,7 +448,7 @@ Run the django webserver
 Run the Django dev server. Add ``0.0.0.0:8000`` to explicitly set the
 host and port, which may be necessary when using remote servers, like
 an AWS EC2 instance. More about `runserver
-<https://docs.djangoproject.com/en/1.11/ref/django-admin/#runserver>`_.
+<https://docs.djangoproject.com/en/stable/ref/django-admin/#runserver>`_.
 
 collect static files
 --------------------
@@ -460,7 +460,7 @@ collect static files
 Collects all static files and places them in a single
 directory. Generally only necessary in production. Also allows all
 static files to be `hosted on another server
-<https://docs.djangoproject.com/en/1.11/howto/static-files/deployment/#serving-static-files-from-a-cloud-service-or-cdn>`_).
+<https://docs.djangoproject.com/en/stable/howto/static-files/deployment/#serving-static-files-from-a-cloud-service-or-cdn>`_).
 
 Django's full ``manage.py`` commands are documented `here
-<https://docs.djangoproject.com/en/1.11/ref/django-admin/#available-commands>`_.
+<https://docs.djangoproject.com/en/stable/ref/django-admin/#available-commands>`_.

--- a/docs/developing/reference/data-model.txt
+++ b/docs/developing/reference/data-model.txt
@@ -66,7 +66,7 @@ Controllers
 
 Arches platform code defines base classes for some of its core data
 models, and uses `proxy models
-<https://docs.djangoproject.com/en/1.11/topics/db/models/#proxy-models>`_
+<https://docs.djangoproject.com/en/stable/topics/db/models/#proxy-models>`_
 to implement their controllers. In smaller classes, "controller" code
 is included with the data model class. This documentation primarily
 discusses the models, but controller behavior is discussed where

--- a/docs/installing/docker.txt
+++ b/docs/installing/docker.txt
@@ -17,7 +17,7 @@ Docker is a platform that allows you to package, distribute, and run application
     Containers allow a developer to package up an application with all of the parts
     it needs, such as libraries and other dependencies, and ship it all out as one package. By doing so, the developer can be assured that the application will run on any other Linux machine regardless of any customized settings that machine might have that could differ from the machine used for writing and testing the code.
 
-We recommend that you gain some understanding about how Docker works as well as some basic proficiency with using Docker before attempting to deploy Arches user Docker. These tutorials can introduce you to the basics of using Docker: https://docker-curriculum.com/ or https://www.howtogeek.com/733522/docker-for-beginners-everything-you-need-to-know/
+We recommend that you gain some understanding about how Docker works as well as some basic proficiency with using Docker before attempting to deploy Arches using Docker. These tutorials can introduce you to the basics of using Docker: https://docker-curriculum.com/ or https://www.howtogeek.com/733522/docker-for-beginners-everything-you-need-to-know/
 
 This document will guide you through the process of using Docker to install Arches on your system. Even if you do not want to use Docker to deploy Arches, the review of Arches Docker setups can still provide a useful guide to see how various dependencies and configurations fit together.
 

--- a/docs/installing/installation.txt
+++ b/docs/installing/installation.txt
@@ -15,9 +15,9 @@ Create a Virtual Environment
 
 .. sidebar:: Virtual Environment Reference
 
-    If you are unfamiliar with virtual environments, please take a look at the `Python documentation <https://docs.python.org/3.7/tutorial/venv.html>`_ before continuing.
+    If you are unfamiliar with virtual environments, please take a look at the `Python documentation <https://docs.python.org/3.8/tutorial/venv.html>`_ before continuing.
 
-You need a **Python 3.7+** virtual environment. :ref:`Skip ahead <Install Arches with pip>` if you have already created and activated one. Otherwise, use the commands below for a quick start.
+You need a **Python 3.8+** virtual environment. :ref:`Skip ahead <Install Arches with pip>` if you have already created and activated one. Otherwise, use the commands below for a quick start.
 
 **Create a virtual environment**::
 
@@ -27,7 +27,7 @@ This will generate a new directory called ``ENV``.
 
 .. note::
 
-  On some linux distributions, if the python version is less than 3.7, entering the following command may yield an error but it should alert you to any dependencies you may need to install, after which you'll be able to run this command.
+  On some linux distributions, if the python version is less than 3.8, entering the following command may yield an error but it should alert you to any dependencies you may need to install, after which you'll be able to run this command.
 
 **Activate the virtual environment**
 
@@ -50,7 +50,7 @@ The following are relative paths to an ``activate`` script within ENV.
     python
 
 This will run the Python interpreter and tell you what version is in use. If you don't
-see at least 3.7, check your original Python installation, delete the entire ``ENV``
+see at least 3.8, check your original Python installation, delete the entire ``ENV``
 directory, and create a new virtual environment. Use ``exit()`` or ``ctrl+C`` to
 leave the interpreter.
 

--- a/docs/installing/installation.txt
+++ b/docs/installing/installation.txt
@@ -124,7 +124,7 @@ In your current terminal, run the Django development server::
 
 Then, in a second terminal, navigate to the root directory of the project ( you should be on the same level as `package.json`) and build a frontend asset bundle::
 
-    cd my_project/myproject
+    cd my_project/my_project
     yarn build_development
 
 .. note::

--- a/docs/installing/requirements-and-dependencies.txt
+++ b/docs/installing/requirements-and-dependencies.txt
@@ -22,8 +22,8 @@ Software Dependencies
 
 Arches requires the following software packages to be installed and available. Ubuntu Linux users see below for an installation script.
 
-:Python >= 3.7: - Installation: https://www.python.org/downloads/
-    - Python 3.7 and later comes with pip
+:Python >= 3.8: - Installation: https://www.python.org/downloads/
+    - Python 3.8 and later comes with pip
     - **Windows** You must choose 32-bit or 64-bit Python based on your system architecture.
     - **macOS** This guide works well if you wish to install via `brew`: https://docs.python-guide.org/starting/install3/osx/
 :PostgreSQL >= 12 with PostGIS 3:

--- a/docs/installing/requirements-and-dependencies.txt
+++ b/docs/installing/requirements-and-dependencies.txt
@@ -46,7 +46,7 @@ To support long-running task management, like large user downloads, you must ins
 Scripted Dependency Installation
 --------------------------------
 
-For Ubuntu we maintain an `ubuntu_setup.sh <https://raw.githubusercontent.com/archesproject/arches/stable/7.1.0/arches/install/ubuntu_setup.sh>`_ script to install dependencies. It works for 18.04 and 20.04, and preliminary testing shows it be compatible with 22.04 as well.
+For Ubuntu we maintain an `ubuntu_setup.sh <https://raw.githubusercontent.com/archesproject/arches/stable/7.1.0/arches/install/ubuntu_setup.sh>`_ script to install dependencies. It works for 18.04 and 20.04, and preliminary testing shows it to be compatible with 22.04 as well.
 
 .. code-block:: bash
 


### PR DESCRIPTION
### brief description of changes
- Fix typos
- `myproject` -> `my_project` per previous steps of tutorial
- Use full path to `requirements.txt`
- Link to stable versions of Django docs (so that we are not continually updating 1.11 -> 2.x -> 3.x etc.)
- Update `url()` examples to use `path()` (deprecated in Django 3.1)
- Suggest Python 3.8 as minimum (due to [importlib_metadata](https://github.com/python/importlib_metadata/issues/411#issuecomment-1279757777) issue)

#### issues addressed
Closes #356 

This box **must** be checked
- [x] the PR branch was originally made from the base branch

This box **should** be checked
- [ ] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [x] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
