### PR TITLE
Describe celery workaround on Apple Silicon (M1) Macs

### DIFF
--- a/docs/developing/advanced/task-management.txt
+++ b/docs/developing/advanced/task-management.txt
@@ -59,12 +59,20 @@ For your tasks to run both your broker service and a Celery worker need to be ru
 want to run a worker as service. One way to do this is to use supervisord. For more information see: :ref:`setting-up-supervisord-for-celery`
 
 However for development, you probably want to run your worker in a terminal. To do so just cd into your project's root
-directory with your virtual environment activated and and run:
+directory with your virtual environment activated and run:
 
 .. code-block:: bash
 
     python manage.py celery start
 
+Users of Apple Silicon Macs may encounter ``billiard.exceptions.WorkerLostError`` following a warning
+emitted by the OS explaining it is "crashing instead" rather than unsafely calling ``fork()``. Until this
+`issue <https://github.com/celery/celery/issues/7324>`_ is resolved by ``celery``, launching like so will
+silence the errors:
+
+.. code-block:: bash
+
+    OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES python manage.py celery start
 
 Note that in the event of celery errors which do not clearly indicate what is breaking or preventing your tasks from succeeding, we recommend running the following command instead for the purpose of debugging and isolating any unhandled exceptions:
 


### PR DESCRIPTION
### brief description of changes
Add a workaround for developers on apple silicon macs to be able to launch celery.

#### issues addressed
Closes #362

This box **must** be checked
- [x] the PR branch was originally made from the base branch

This box **should** be checked
- [ ] after these changes the docs build locally without error 
- [x] (no errors in my diff; existing errors exist)

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [ ] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
