### PR TITLE
Added requirement for graph identification in resource PUT

### DIFF
--- a/docs/developing/reference/api.txt
+++ b/docs/developing/reference/api.txt
@@ -495,9 +495,13 @@ Resources
             }
         }
 
-.. http:put:: /resources/{uuid:resouce instance id}
+.. http:put:: /resources/{uuid: graph id}/{uuid:resource instance id} (or) PUT /resources/{string: graph slug}/{uuid:resource instance id}
 
-    updates a single resource instance
+    .. note::
+        To get or set the slug for the graph, navigate to the root node of the :ref:`Graph Designer`.
+
+
+    Updates a single resource instance
 
     :query format: {"json-ld", "arches-json"}
     :query indent: number of spaces to indent json output

--- a/docs/developing/reference/api.txt
+++ b/docs/developing/reference/api.txt
@@ -495,10 +495,12 @@ Resources
             }
         }
 
-.. http:put:: /resources/{uuid: graph id}/{uuid:resource instance id} (or) PUT /resources/{string: graph slug}/{uuid:resource instance id}
+.. http:put:: /resources/{uuid: graph id}/{uuid:resource instance id}
 
     .. note::
-        To get or set the slug for the graph, navigate to the root node of the :ref:`Graph Designer`.
+        Instead of identifying a graph by a UUID, one can also identify a graph by by a slug identifier. 
+        To get or set the slug for the graph, navigate to the root node of the :ref:`Graph Designer`. A request using a slug identifier for a graph looks like:
+        ``PUT /resources/{string: graph slug}/{uuid:resource instance id}``
 
 
     Updates a single resource instance
@@ -512,7 +514,7 @@ Resources
 
     .. code-block:: none
 
-        curl -H "Authorization: Bearer {token}" -X PUT -d {data in json-ld format} http://localhost:8000/resources/{uuid: graph id}/{resource instance id}
+        curl -H "Authorization: Bearer {token}" -X PUT -d {data in json-ld format} http://localhost:8000/resources/{graph id}/{resource instance id}
 
         curl -H "Authorization: Bearer zo41Q1IMgAW30xOroiCUxjv3yci8Os" -X PUT \
         -d '{

--- a/docs/developing/reference/api.txt
+++ b/docs/developing/reference/api.txt
@@ -512,7 +512,7 @@ Resources
 
     .. code-block:: none
 
-        curl -H "Authorization: Bearer {token}" -X PUT -d {data in json-ld format} http://localhost:8000/resources//{uuid: graph id}/{resource instance id}
+        curl -H "Authorization: Bearer {token}" -X PUT -d {data in json-ld format} http://localhost:8000/resources/{uuid: graph id}/{resource instance id}
 
         curl -H "Authorization: Bearer zo41Q1IMgAW30xOroiCUxjv3yci8Os" -X PUT \
         -d '{

--- a/docs/developing/reference/api.txt
+++ b/docs/developing/reference/api.txt
@@ -512,7 +512,7 @@ Resources
 
     .. code-block:: none
 
-        curl -H "Authorization: Bearer {token}" -X PUT -d {data in json-ld format} http://localhost:8000/resources/{resource instance id}
+        curl -H "Authorization: Bearer {token}" -X PUT -d {data in json-ld format} http://localhost:8000/resources//{uuid: graph id}/{resource instance id}
 
         curl -H "Authorization: Bearer zo41Q1IMgAW30xOroiCUxjv3yci8Os" -X PUT \
         -d '{


### PR DESCRIPTION
### brief description of changes
Adds the requirement for the graph to be identified when making a PUT request for creating or updating a resource. 


#### issues addressed
Relates to https://github.com/archesproject/arches/issues/9968

#### further comments
<!-- feel free to delete this header if you have no comments -->

---

This box **must** be checked
- [x] the PR branch was originally made from the base branch

This box **should** be checked
- [x] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [ ] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
