### PR TITLE
Update example for Django 4.2 storage settings

### DIFF
--- a/docs/deployment/using-aws-s3.txt
+++ b/docs/deployment/using-aws-s3.txt
@@ -141,7 +141,7 @@ app.  Before beginning, you will need to have set up and logged into your AWS ac
 
         .. code-block::
 
-          DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+          STORAGES["default"] = 'storages.backends.s3boto3.S3Boto3Storage'
           AWS_STORAGE_BUCKET_NAME = 'aws_bucket_name'
           AWS_ACCESS_KEY_ID = 'aws_access_key_id'
           AWS_SECRET_ACCESS_KEY = 'aws_secret_access_key'


### PR DESCRIPTION
### brief description of changes
`DEFAULT_FILE_STORAGE` was deprecated in Django 4.2, which is used in Arches 7.5. Update the docs to avoid suggesting the use of a deprecated setting.

See:
https://docs.djangoproject.com/en/4.2/releases/4.2/#custom-file-storages

This box **must** be checked
- [x] the PR branch was originally made from the base branch

This box **should** be checked
- [ ] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [x] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
(This should only get cherry-picked to 7.5)
