### PR TITLE
7.4 <-cross references to card types

### DIFF
--- a/docs/administering/designing-the-database.txt
+++ b/docs/administering/designing-the-database.txt
@@ -98,8 +98,8 @@ When you select a card or a widget, you will see the Card Manager or Widget Mana
 
 .. tip:: While working with the Cards Tab, you may need to go back and change a node in the Graph Tab. Be aware that though you may expect node changes in the Graph Tab to cascade to widget configurations in the Cards Tab, this does not always happen. Be sure to double-check your work!
 
-Card Type
----------
+Card Types
+----------
 
 The UI of a card can be configured using a card component. Note that when you click a node in the card tree, the "Card Configuration" panel on the right-hand side of the screen will show the card component in a dropdown called "Card Type".
 

--- a/docs/developing/extending/extensions/card-components.rst
+++ b/docs/developing/extending/extensions/card-components.rst
@@ -9,6 +9,9 @@ Component that should suit most needs, but you can also create and
 register custom Card Components to extend the front-end behavior of
 Arches.
 
+Before exploring how do make customized Cards, please review documentation
+about available :ref:`Card Types` standard with Arches.
+
 
 .. note:
 


### PR DESCRIPTION
### brief description of changes
Card types documentation is hard to find, making so it appeared this card lacked explanation. 

#### issues addressed
[Documentation already existed but was hard to find](https://github.com/archesproject/arches-docs/issues/355)

#### further comments
We probably need to do LOTS more to add cross references and guides for how to find useful info

---

This box **must** be checked
- [x] the PR branch was originally made from the base branch

This box **should** be checked
- [x] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [x] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
