### PR TITLE
Update example custom components for 7.x

### DIFF
--- a/docs/developing/extending/extensions/functions.rst
+++ b/docs/developing/extending/extensions/functions.rst
@@ -184,7 +184,7 @@ where you'll put any forms or other UI artifacts used to configure the
 Function.
 
 Developing your Function's UI component is very similar to developing
-`Widgets`_. More specific guidelines are in progress, but for now,
+:ref:`Widgets`. More specific guidelines are in progress, but for now,
 refer to the sample code in your project's
 ``templates/views/components/functions/`` directory, and gain a little
 more insight from the ``templates/views/components/widgets/``

--- a/docs/developing/extending/extensions/resource-reports.rst
+++ b/docs/developing/extending/extensions/resource-reports.rst
@@ -29,7 +29,11 @@ Sample report ``.js`` file:
 
 .. code-block:: bash
 
-        define(['knockout', 'viewmodels/report'], function(ko, ReportViewModel) {
+        define([
+            'knockout',
+            'viewmodels/report',
+            'templates/views/report-templates/custom_report.htm'
+        ], function(ko, ReportViewModel, customReportTemplate) {
             return ko.components.register('custom_report', {
                 viewModel: function(params) {
                     params.configKeys = [];
@@ -39,7 +43,7 @@ Sample report ``.js`` file:
                     ReportViewModel.apply(this, [params]);
                     // Put custom report logic here
                 },
-                template: { require: 'text!report-templates/custom_report' }
+                template: customReportTemplate,
             });
         });
 

--- a/docs/developing/extending/extensions/workflows.rst
+++ b/docs/developing/extending/extensions/workflows.rst
@@ -73,9 +73,10 @@ The workflow's behavior is defined in ``quick-resource-create-workflow.js``. You
         'jquery',
         'arches',
         'viewmodels/workflow',
+        'templates/views/components/plugins/quick-resource-create-workflow.htm',
         // DEFINE EXTRA STEP COMPONENTS HERE AS NEEDED
         'views/components/workflows/final-step'
-    ], function(ko, $, arches, Workflow) {
+    ], function(ko, $, arches, Workflow, quickResourceCreateWorkflowTemplate) {
         return ko.components.register('quick-resource-create-workflow', {
             viewModel: function(params) {
                 this.componentName = 'quick-resource-create-workflow';
@@ -85,7 +86,7 @@ The workflow's behavior is defined in ``quick-resource-create-workflow.js``. You
                 ];
                 Workflow.apply(this, [params]);
             },
-            template: { require: 'text!templates/views/components/plugins/quick-resource-create-workflow.htm' }
+            template: quickResourceCreateWorkflowTemplate,
         });
     });
 

--- a/docs/examples/boolean.js
+++ b/docs/examples/boolean.js
@@ -1,4 +1,4 @@
-define(['knockout'], function (ko) {
+define(['knockout', 'datatype-config-templates/boolean.htm'], function (ko, booleanTemplate) {
     var name = 'boolean-datatype-config';
     ko.components.register(name, {
         viewModel: function(params) {
@@ -23,7 +23,7 @@ define(['knockout'], function (ko) {
                 });
             }
         },
-        template: { require: 'text!datatype-config-templates/boolean' }
+        template: booleanTemplate,
     });
     return name;
 });

--- a/docs/examples/date.js
+++ b/docs/examples/date.js
@@ -1,4 +1,4 @@
-define(['knockout'], function (ko) {
+define(['knockout', 'datatype-config-templates/date.htm'], function (ko, dateTemplate) {
     var name = 'date-datatype-config';
     ko.components.register(name, {
         viewModel: function(params) {
@@ -21,7 +21,7 @@ define(['knockout'], function (ko) {
                 });
             }
         },
-        template: { require: 'text!datatype-config-templates/date' }
+        template: dateTemplate,
     });
     return name;
 });

--- a/docs/examples/default-card.js
+++ b/docs/examples/default-card.js
@@ -1,4 +1,8 @@
-define(['knockout', 'bindings/scrollTo'], function(ko) {
+define([
+    'knockout',
+    'templates/views/components/cards/default.htm',
+    'bindings/scrollTo'
+], function(ko, defaultCardTemplate) {
     var viewModel = function(params) {
         this.state = params.state || 'form';
         this.preview = params.preview;
@@ -21,8 +25,6 @@ define(['knockout', 'bindings/scrollTo'], function(ko) {
     };
     return ko.components.register('default-card', {
         viewModel: viewModel,
-        template: {
-            require: 'text!templates/views/components/cards/default.htm'
-        }
+        template: defaultCardTemplate,
     });
 });

--- a/docs/examples/quick-resource-create-workflow.js
+++ b/docs/examples/quick-resource-create-workflow.js
@@ -3,8 +3,9 @@ define([
     'jquery',
     'arches',
     'viewmodels/workflow',
+    'templates/views/components/plugins/quick-resource-create-workflow.htm',
     'views/components/workflows/final-step'
-], function(ko, $, arches, Workflow) {
+], function(ko, $, arches, Workflow, quickResourceCreateWorkflowTemplate) {
     return ko.components.register('quick-resource-create-workflow', {
         viewModel: function(params) {
             this.componentName = 'quick-resource-create-workflow';
@@ -95,6 +96,6 @@ define([
             ];
             Workflow.apply(this, [params]);
         },
-        template: { require: 'text!templates/views/components/plugins/quick-resource-create-workflow.htm' }
+        template: quickResourceCreateWorkflowTemplate,
     });
 });

--- a/docs/examples/sample-function.js
+++ b/docs/examples/sample-function.js
@@ -2,8 +2,9 @@ define(['knockout',
         'knockout-mapping',
         'views/list',
         'viewmodels/function',
-        'bindings/chosen'],
-function (ko, koMapping, ListView, FunctionViewModel, chosen) {
+        'bindings/chosen',
+        'templates/views/components/functions/sample-function.htm',
+    ], function (ko, koMapping, ListView, FunctionViewModel, chosen, sampleFunctionTemplate) {
     return ko.components.register('views/components/functions/sample-function', {
         viewModel: function(params) {
             FunctionViewModel.apply(this, arguments);
@@ -29,7 +30,7 @@ function (ko, koMapping, ListView, FunctionViewModel, chosen) {
             window.setTimeout(function(){$("select[data-bind^=chosen]").trigger("chosen:updated")}, 300);
         },
         template: {
-            require: 'text!templates/views/components/functions/sample-function.htm'
+            require: sampleFunctionTemplate,
         }
     });
 })

--- a/docs/examples/sample-plugin.js
+++ b/docs/examples/sample-plugin.js
@@ -1,14 +1,15 @@
 define([
     'jquery',
     'knockout',
-    'arches'
-], function($, ko, arches) {
+    'arches',
+    'templates/views/components/plugins/sample-plugin.htm',
+], function($, ko, arches, samplePluginTemplate) {
 
     var SamplePlugin = function(params) {
     };
 
     return ko.components.register('sample-plugin', {
         viewModel: SamplePlugin,
-        template: { require: 'text!templates/views/components/plugins/sample-plugin.htm' }
+        template: samplePluginTemplate,
     });
 });

--- a/docs/examples/sample-widget.js
+++ b/docs/examples/sample-widget.js
@@ -1,4 +1,9 @@
-define(['knockout', 'underscore', 'viewmodels/widget'], function (ko, _, WidgetViewModel) {
+define([
+    'knockout',
+    'underscore',
+    'viewmodels/widget',
+    'templates/views/components/widgets/sample-widget.htm'
+], function (ko, _, WidgetViewModel, sampleWidgetTemplate) {
     /**
     * registers a text-widget component for use in forms
     * @function external:"ko.components".text-widget
@@ -31,6 +36,6 @@ define(['knockout', 'underscore', 'viewmodels/widget'], function (ko, _, WidgetV
                 return res;
             }, this);
         },
-        template: { require: 'text!templates/views/components/widgets/sample-widget.htm' }
+        template: sampleWidgetTemplate,
     });
 });


### PR DESCRIPTION
### brief description of changes
In 7.0, the pattern for registering custom components changed slightly. See:

https://github.com/archesproject/arches/blob/77dcfef2322967163551b27dd34e4dbbd316e2ef/releases/7.0.0.md?plain=1#L176-L206



This box **must** be checked
- [x] the PR branch was originally made from the base branch

This box **should** be checked
- [ ] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [ ] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
