### PR TITLE
Added macOS path instructions (issue #410)

### DIFF
--- a/docs/installing/installation.rst
+++ b/docs/installing/installation.rst
@@ -115,7 +115,7 @@ Create a Project
 
 .. warning::
 
-    On macOS, ``pip install`` will often fail because the installation of ``psycopg`` (a Postgres driver for Python) needs to access Postgres' ``pg_config`` and does so by looking in the ``PATH``. Some methods for installing Postgres on macOS will require one to manually edit their user profile to edit their ZSH configuration file (`see background <https://www.freecodecamp.org/news/how-do-zsh-configuration-files-work/>`_). You'll need to create or update your user's ``.zhrc`` as so:
+    On macOS, ``pip install`` will often fail because the installation of ``psycopg`` (a Postgres driver for Python) needs to access Postgres' ``pg_config`` and does so by looking in the ``PATH``. Some methods for installing Postgres on macOS will require one to manually edit their user profile to edit their ZSH configuration file (`see background <https://www.freecodecamp.org/news/how-do-zsh-configuration-files-work/>`_). You'll need to create or update your user's ``.zshrc`` as so:
 
     .. code-block:: bash
 

--- a/docs/installing/installation.rst
+++ b/docs/installing/installation.rst
@@ -103,6 +103,7 @@ Create a Project
 
     You can add ``--directory path/to/dir`` to change the directory your new project will be created in.
 
+
 .. warning::
 
     On Windows, open ``my_project\my_project\settings_local.py`` and add the following line::
@@ -110,6 +111,25 @@ Create a Project
         GDAL_LIBRARY_PATH = "C:/OSGeo4W64/bin/gdal201.dll"
 
     Be sure to adjust the path as necessary for your GDAL installation, and note the *forward* slashes.
+
+
+.. warning::
+
+    On macOS, ``pip install`` will often fail because the installation of ``psycopg`` (a Postgres driver for Python) needs to access Postgres' ``pg_config`` and does so by looking in the ``PATH``. Some methods for installing Postgres on macOS will require one to manually edit their user profile to edit their ZSH configuration file (`see background <https://www.freecodecamp.org/news/how-do-zsh-configuration-files-work/>`_). You'll need to create or update your user's ``.zhrc`` as so:
+
+    .. code-block:: bash
+
+        # Use a text editor to create or modify your user's .zshrc file
+        nano ~/.zshrc
+
+        # Add this line to the .zshrc file, then save the update.
+        export PATH="/Applications/Postgres.app/Contents/Versions/14/bin:$PATH"
+
+        # Make sure the update to the .zshrc file takes effect
+        source ~/.zshrc
+
+    In addition, a macOS installation will likely require some modifications to ``settings.py`` (or ``settings_local.py``) to specify GDAL and GEOS related paths. (See :ref:`macOS and GDAL, GEOS`)
+
 
 Setup the Database
 -------------------

--- a/docs/installing/installation.rst
+++ b/docs/installing/installation.rst
@@ -1,4 +1,4 @@
-﻿######################
+######################
 Installing Core Arches
 ######################
 
@@ -115,7 +115,7 @@ Create a Project
 
 .. warning::
 
-    On macOS, ``pip install`` will often fail because the installation of ``psycopg`` (a Postgres driver for Python) needs to access Postgres' ``pg_config`` and does so by looking in the ``PATH``. Some methods for installing Postgres on macOS will require one to manually edit their user profile to edit their ZSH configuration file (`see background <https://www.freecodecamp.org/news/how-do-zsh-configuration-files-work/>`_). You'll need to create or update your user's ``.zshrc`` as so:
+    On macOS, ``pip install`` will often fail because the installation of ``psycopg`` (a Postgres driver for Python) needs to access Postgres' ``pg_config`` and does so by looking in the ``PATH``. Some methods for installing Postgres on macOS will require one to manually edit their user profile to edit their profile configuration file e.g. ``.zprofile`` or ``.zshrc`` (`see background <https://www.freecodecamp.org/news/how-do-zsh-configuration-files-work/>`_). You'll need to create or update your user's ``.zshrc`` as so:
 
     .. code-block:: bash
 
@@ -128,7 +128,7 @@ Create a Project
         # Make sure the update to the .zshrc file takes effect
         source ~/.zshrc
 
-    In addition, a macOS installation will likely require some modifications to ``settings.py`` (or ``settings_local.py``) to specify GDAL and GEOS related paths. (See :ref:`macOS and GDAL, GEOS`)
+    In addition, a macOS installation will likely require some modifications to ``settings.py`` (or ``settings_local.py``) in your project directory to specify GDAL and GEOS related paths. (See :ref:`macOS and GDAL, GEOS`)
 
 
 Setup the Database

--- a/docs/installing/requirements-and-dependencies.rst
+++ b/docs/installing/requirements-and-dependencies.rst
@@ -35,7 +35,9 @@ Arches requires the following software packages to be installed and available. U
 :Elasticsearch 8: - Installers: https://www.elastic.co/downloads/past-releases/elasticsearch-8-5-1
     - Elasticsearch is integral to Arches and can be installed and configured many ways.
       For more information, see :ref:`Arches and Elasticsearch`.
-:GDAL >= 2.2.x: - **Windows** Use the `OSGeo4W installer <https://trac.osgeo.org/osgeo4w/>`_, and choose to install the GDAL package (you don't need QGIS or GRASS). After installation, add ``C:\OSGeo4W64\bin`` to your system's ``PATH`` environment variable.
+:GDAL >= 2.2.x: 
+    - **Windows** Use the `OSGeo4W installer <https://trac.osgeo.org/osgeo4w/>`_, and choose to install the GDAL package (you don't need QGIS or GRASS). After installation, add ``C:\OSGeo4W64\bin`` to your system's ``PATH`` environment variable.
+    - **macOS** (See :ref:`macOS and GDAL, GEOS` below)
 :Node.js 16.x (recommended): - Installation: https://nodejs.org/ (choose the installer appropriate to your operating system).
     - NOTE: Arches may not be compatible with later versions of Node.js (after 16) `(see discussion) <https://community.archesproject.org/t/newbie-v7-install-experience-some-hints-and-tips/1782>`_.
 :Yarn >= 1.22, < 2: - Recommended Installation: https://classic.yarnpkg.com/en/docs/install (One can also install Yarn via `apt` on Linux operating systems, `see example <https://github.com/archesproject/arches/blob/f06b838cf1be23471644f8528a630d65c8bff9a7/arches/install/ubuntu_setup.sh#L51>`_).
@@ -45,6 +47,26 @@ To support long-running task management, like large user downloads, you must ins
 
 :Brokers: - Options: https://docs.celeryproject.org/en/stable/getting-started/first-steps-with-celery.html#choosing-a-broker
     - Once you have a broker installed, read more about :ref:`Task Management` in Arches.
+
+
+macOS and GDAL, GEOS
+--------------------
+Satisfying GDAL and GEOS requirements for **macOS** installations can involve some additional complexity, especially if using the Apple M1 series of ARM-based system-on-a-chip (SoC) hardware. You'll need to install GDAL and GEOS in preparation for installing Python libraries that need this requirement. To install GDAL and GEOS:
+
+.. code-block:: bash
+
+    brew install gdal 
+    brew install geos
+
+Currently, GDAL version 3.8 and GEOS version 3.12 work with Arches running on macOS. Once you've completed installation of dependencies and have created an Arches project (see :ref:`Create a Project`), you will likely need to specify the paths to the GDAL and GEOS libraries in your ``settings.py`` file. Here is an example of what to add to ``settings.py`` in a macOS installation:
+
+.. code-block:: python
+
+    GDAL_LIBRARY_PATH = '/opt/homebrew/Cellar/gdal/3.8.4_3/lib/libgdal.34.3.8.4.dylib'
+    GEOS_LIBRARY_PATH = '/opt/homebrew/Cellar/geos/3.12.1/lib/libgeos_c.dylib'
+
+
+
 
 Scripted Dependency Installation
 --------------------------------

--- a/docs/installing/requirements-and-dependencies.rst
+++ b/docs/installing/requirements-and-dependencies.rst
@@ -58,13 +58,14 @@ Satisfying GDAL and GEOS requirements for **macOS** installations can involve so
     brew install gdal 
     brew install geos
 
-Currently, GDAL version 3.8 and GEOS version 3.12 work with Arches running on macOS. Once you've completed installation of dependencies and have created an Arches project (see :ref:`Create a Project`), you will likely need to specify the paths to the GDAL and GEOS libraries in your ``settings.py`` file. Here is an example of what to add to ``settings.py`` in a macOS installation:
+Currently, GDAL version 3.8 and GEOS version 3.12 work with Arches running on macOS. Once you've completed installation of dependencies and have created an Arches project (see :ref:`Create a Project`), you will likely need to specify the paths to the GDAL and GEOS libraries in your ``settings.py`` (or ``settings_local.py``) file. Here is an example of what to add to ``settings.py`` (or ``settings_local.py``) in a macOS installation:
 
 .. code-block:: python
 
     GDAL_LIBRARY_PATH = '/opt/homebrew/Cellar/gdal/3.8.4_3/lib/libgdal.34.3.8.4.dylib'
     GEOS_LIBRARY_PATH = '/opt/homebrew/Cellar/geos/3.12.1/lib/libgeos_c.dylib'
 
+Please note that the actual paths that you need to specify for ``GDAL_LIBRARY_PATH`` and ``GEOS_LIBRARY_PATH`` will vary depending on versions and the specfics of your installation of these dependencies. 
 
 
 


### PR DESCRIPTION
### brief description of changes
Updates macOS dependency path related instructions.

#### issues addressed
https://github.com/archesproject/arches-docs/issues/409
https://github.com/archesproject/arches-docs/issues/410


#### further comments
See changes previewed here:
https://arches.readthedocs.io/en/mac_7_5/installing/requirements-and-dependencies/

and

https://arches.readthedocs.io/en/mac_7_5/installing/installation/


---

This box **must** be checked
- [x] the PR branch was originally made from the base branch

This box **should** be checked
- [x] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [x] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
