### PR TITLE
Replace references to yarn

### DIFF
--- a/docs/deployment/arches-in-production.rst
+++ b/docs/deployment/arches-in-production.rst
@@ -58,12 +58,12 @@ Build Production Frontend Assets
 
 In deploying Arches in production, have a choice in how you bundle frontend assets (CSS, Javascript, etc).
 
-You can use ``yarn build_development`` followed by ``manage.py collectstatic`` to provide unminified frontend bundles.
+You can use ``npm run build_development`` followed by ``manage.py collectstatic`` to provide unminified frontend bundles.
 These will be larger files, so there will be a hit with respect to network performance.
 
 Alternatively, you can build production assets for the frontend, which will be minified and therefore faster for
 clients to download. To make production frontend assets, use the ``manage.py build_production`` management command
-(this combines both ``yarn build_production`` and ``manage.py collectstatic``). Please note however, you will need
+(this combines both ``npm run build_production`` and ``manage.py collectstatic``). Please note however, you will need
 at least *8GB* of RAM for the production frontend asset build itself (and much more if you're also running the
 database and backend Arches server on the same host), and you will need lots of time. Depending on your system
 specifics, this can take multiple hours to complete.

--- a/docs/developing/extending/creating-extensions.rst
+++ b/docs/developing/extending/creating-extensions.rst
@@ -162,11 +162,11 @@ By default, the only dependency in a new project's ``package.json`` file is Arch
         }
     }
 
-This means that when you run ``yarn install`` on this file, all dependencies from the corresponding branch of the core Arches repo will be installed (in this example, `package.json from stable/6.0.1 <https://github.com/archesproject/arches/blob/stable/6.0.1/package.json>`_).
+This means that when you run ``npm install`` on this file, all dependencies from the corresponding branch of the core Arches repo will be installed (in this example, `package.json from stable/6.0.1 <https://github.com/archesproject/arches/blob/stable/6.0.1/package.json>`_).
 
-**To add a new package**, you just need to run ``yarn add <package name>`` in your project. This will install the new package and update your ``package.json`` file accordingly.
+**To add a new package**, you just need to run ``npm install <package name>`` in your project. This will install the new package and update your ``package.json`` file accordingly.
 
-For example, to add `OpenLayers <https://openlayers.org>`_, enter the ``my_project`` directory and run ``yarn add ol``. Your ``package.json`` will now look something like:
+For example, to add `OpenLayers <https://openlayers.org>`_, enter the ``my_project`` directory and run ``npm install ol``. Your ``package.json`` will now look something like:
 
 .. code-block:: json
 
@@ -182,4 +182,4 @@ If you are developing a project, keep track of which version of Arches you are d
 
 .. note::
 
-    When you register a new extension there is no way to automaticate the installation of a new JS dependency, so you'll need to manually run ``yarn add`` as described above.
+    When you register a new extension there is no way to automaticate the installation of a new JS dependency, so you'll need to manually run ``npm install `` as described above.

--- a/docs/developing/getting-started/creating-a-development-environment.rst
+++ b/docs/developing/getting-started/creating-a-development-environment.rst
@@ -171,7 +171,7 @@ In general, you should always expect to
 3) Reinstall javascript dependencies in ``my_project/my_project``::
 
     (ENV)$ cd my_project/my_project
-    (ENV)my_project/my_project$ yarn install
+    (ENV)my_project/my_project$ npm install
 
 **Finally**, if you have added custom logic or content to your project, you must make sure to account for any changes in the core Arches content that you have overwritten or inherited.
 

--- a/docs/developing/vue/arches-vue-integration.md
+++ b/docs/developing/vue/arches-vue-integration.md
@@ -182,9 +182,9 @@ We have integrated TypeScript and ESLint linting as essential components of our 
 
 ### Enforcement
 
-While this integration brings significant benefits to our Vue projects, it's important to note that newly written components will be affected by TypeScript and ESLint linting rules. Developers will need to adhere to TypeScript typing conventions and ESLint rules when writing new components to ensure consistency and compliance with the established coding standards. This enforcement takes place in the `build_development`, `build_test`, and `build_production` yarn processes. Previously written components will not be affected.
+While this integration brings significant benefits to our Vue projects, it's important to note that newly written components will be affected by TypeScript and ESLint linting rules. Developers will need to adhere to TypeScript typing conventions and ESLint rules when writing new components to ensure consistency and compliance with the established coding standards. This enforcement takes place in the `build_development`, `build_test`, and `build_production` npm processes. Previously written components will not be affected.
 
-We have also added the `eslint:check`, `eslint:watch`, `ts:check`, and `ts:watch` yarn scripts.
+We have also added the `eslint:check`, `eslint:watch`, `ts:check`, and `ts:watch` npm scripts.
 
 ### Separate Processes
 
@@ -241,8 +241,8 @@ In this example, we import the `useGettext` function from vue3-gettext and destr
 
 Before using internationalization features, it's important to run the following commands to extract and compile translations:
 
-Extract Translations: Run `yarn gettext:extract` to extract translations from the source code and generate template .pot files.
-Compile Translations: Run `yarn gettext:compile` to compile translated .po files into machine-readable .json files that can be used by the application.
+Extract Translations: Run `npm run gettext:extract` to extract translations from the source code and generate template .pot files.
+Compile Translations: Run `npm run gettext:compile` to compile translated .po files into machine-readable .json files that can be used by the application.
 
 For further information, please reference the [vue3-gettext documentation](https://github.com/jshmrtn/vue3-gettext)
 
@@ -366,7 +366,7 @@ describe('ExampleComponent', () => {
 To run your tests, use the vitest command in your terminal:
 
 ```bash
-yarn vitest
+npm run vitest
 ```
 
 **By following this documentation, you can set up and maintain comprehensive unit and component testing that catches bugs early and improves code quality. For further details, refer to the [Vitest documentation](https://vitest.dev/).**

--- a/docs/installing/installation.rst
+++ b/docs/installing/installation.rst
@@ -145,13 +145,13 @@ In your current terminal, run the Django development server (with the Arches vir
 Then, in a second terminal, activate the virtual environment used by Arches (this is a required step). Then navigate to the root directory of the project. ( you should be on the same level as `package.json`) and build a frontend asset bundle::
 
     cd my_project/my_project
-    yarn build_development
+    npm run build_development
 
 If you have trouble with this step, see :ref:`Troubleshooting Frontend Builds` below.
 
 .. note::
 
-    ``yarn build_development`` creates a static frontend asset bundle. Any changes made to frontend files (eg. ``.js``) will not be viewable until the asset bundle is rebuilt. run ``yarn build_development`` again to update the asset bundle, or run ``yarn start`` to run an asset bundler server that will detect changes to frontend files and rebuild the bundle appropriately.
+    ``npm run build_development`` creates a static frontend asset bundle. Any changes made to frontend files (eg. ``.js``) will not be viewable until the asset bundle is rebuilt. run ``npm run build_development`` again to update the asset bundle, or run ``npm run start`` to run an asset bundler server that will detect changes to frontend files and rebuild the bundle appropriately.
 
 
 
@@ -244,48 +244,46 @@ Troubleshooting Frontend Builds
 
 Building the frontend assets can sometimes be a source of challenge and frustration. Sometimes a "locked down" computer (with strict security configurations) may cause some trouble. If this is the case, you can try the following steps to interate toward a successful build.
 
-1. Edit your ``.yarnrc`` file to disable strict SSL.
-    To do so, navigate to your project's root directory and open the ``.yarnrc`` file in a text editor. Add the following lines to the end of the file:
+1. Configure ``npm`` to disable strict SSL.
     .. code-block:: bash
 
-        cafile null
-        strict-ssl false
+        npm config set cafile null
+        npm config set strict-ssl false
 
-2. **After the above edits, save the file.**
-3. Remove the ``node_modules`` folder and ``yarn.lock`` file if they exist:
+2. Remove the ``node_modules`` folder and ``package-lock.json`` file if they exist:
     .. code-block:: bash
 
         cd path/to/dir/my_project/my_project
         rm -rf node_modules
-        rm yarn.lock
+        rm package-lock.json
 
-4. If you’re using a virtual environment, activate it. ENV should be replaced with the name of your virtual environment.
+3. If you’re using a virtual environment, activate it. ENV should be replaced with the name of your virtual environment.
     .. code-block:: bash
 
         source ENV/bin/activate
 
-5. Run your Arches Django server and leave it running.
+4. Run your Arches Django server and leave it running.
     .. code-block:: bash
 
         python manage.py runserver
 
-6. **Open a *new terminal* to complete the following steps below.**
+5. **Open a *new terminal* to complete the following steps below.**
 
-7. If you’re using a virtual environment, activate it as in step 4 above. ENV should be replaced with the name of your virtual environment.
+6. If you’re using a virtual environment, activate it as in step 4 above. ENV should be replaced with the name of your virtual environment.
     .. code-block:: bash
 
         source ENV/bin/activate
 
-8. Navigate to the same directory as package.json, and install the frontend dependencies:
+7. Navigate to the same directory as package.json, and install the frontend dependencies:
     .. code-block:: bash
 
         cd path/to/dir/my_project/my_project
-        yarn install
+        npm install
 
-9. Once the dependencies are installed, build your static asset bundle:
+8. Once the dependencies are installed, build your static asset bundle:
     .. code-block:: bash
 
-        yarn build_development
+        npm run build_development
 
 
     If successful, you should see a message indicating that the build was successful. A successful build should make a message looking something like this:

--- a/docs/installing/requirements-and-dependencies.rst
+++ b/docs/installing/requirements-and-dependencies.rst
@@ -14,7 +14,7 @@ To begin development or make a test installation of Arches, you will need the fo
     - Depending on how many uploaded files (images, 3d models, etc) you will have, you may need **much** more disk space. We advise an early evaulation of how much space you *think* you'll need, and then provision twice as much just to be safe...
 :Memory (RAM):  - **4GB**
     - This recommendation is based on the fact that ElasticSearch requires 2GB to run, and as per `official ElasticSearch documentation <https://www.elastic.co/guide/en/elasticsearch/guide/current/heap-sizing.html#_give_less_than_half_your_memory_to_lucene>`_ no more than half of your system's memory should be dedicated to ElasticSearch.
-    - In production, you very likely need to increase your memory. In building the production (minified) frontend asset bundle, yarn (all by itself!) will require at least 8GB to run. If you don't have enough memory, yarn will likely return an error, sometimes after several minutes or hours of processing. In production, you may also find it useful to allow ElasticSearch to use `up to 32GB <https://www.elastic.co/guide/en/elasticsearch/guide/current/heap-sizing.html#compressed_oops>`_.
+    - In production, you very likely need to increase your memory. In building the production (minified) frontend asset bundle, npm (all by itself!) will require at least 8GB to run. If you don't have enough memory, npm will likely return an error, sometimes after several minutes or hours of processing. In production, you may also find it useful to allow ElasticSearch to use `up to 32GB <https://www.elastic.co/guide/en/elasticsearch/guide/current/heap-sizing.html#compressed_oops>`_.
 
 
 Software Dependencies
@@ -40,8 +40,6 @@ Arches requires the following software packages to be installed and available. U
     - **macOS** (See :ref:`macOS and GDAL, GEOS` below)
 :Node.js 16.x (recommended): - Installation: https://nodejs.org/ (choose the installer appropriate to your operating system).
     - NOTE: Arches may not be compatible with later versions of Node.js (after 16) `(see discussion) <https://community.archesproject.org/t/newbie-v7-install-experience-some-hints-and-tips/1782>`_.
-:Yarn >= 1.22, < 2: - Recommended Installation: https://classic.yarnpkg.com/en/docs/install (One can also install Yarn via `apt` on Linux operating systems, `see example <https://github.com/archesproject/arches/blob/f06b838cf1be23471644f8528a630d65c8bff9a7/arches/install/ubuntu_setup.sh#L51>`_).
-    - NOTE: We are pointing to the "classic" yarn installer to avoid installation of more recent versions of yarn that are not compatible with Arches via the Node.js `package manager <https://yarnpkg.com/getting-started/install>`_.
 
 To support long-running task management, like large user downloads, you must install a Celery broker like RabbitMQ or Redis:
 
@@ -79,4 +77,4 @@ For Ubuntu we maintain an `ubuntu_setup.sh <https://raw.githubusercontent.com/ar
     wget https://raw.githubusercontent.com/archesproject/arches/stable/7.5.0/arches/install/ubuntu_setup.sh
     source ./ubuntu_setup.sh
 
-You will be prompted before each dependency is installed, or use ``yes | source ./ubuntu_setup.sh`` to install all components (Postgres/PostGIS, Node/Yarn, and ElasticSearch).
+You will be prompted before each dependency is installed, or use ``yes | source ./ubuntu_setup.sh`` to install all components (Postgres/PostGIS, Node/npm, and ElasticSearch).


### PR DESCRIPTION
### brief description of changes
Replace references to yarn, which is removed in 7.6


This box **must** be checked
- [x] the PR branch was originally made from the base branch

This box **should** be checked
- [ ] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [ ] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
