### PR TITLE
Document FILE_TYPE_CHECKING setting

### DIFF
--- a/docs/configuring/settings-beyond-the-ui.rst
+++ b/docs/configuring/settings-beyond-the-ui.rst
@@ -238,7 +238,7 @@ File type checking
 Through the `FILE_TYPE_CHECKING` setting, Arches provides three modes for file type checking:
 
 - `None`: files can be uploaded regardless of the `FILE_TYPES` setting. In addition, the integrity checks described below for .csv, .zip, .xlsx, and .json files are skipped.
-- `"lenient"`: if the type of the uploaded file can be guessed, the following checks are performed:
+- `"lenient"` (Default): If the type of the uploaded file can be guessed, the following checks are performed:
     - The guessed file type must be included in `FILE_TYPES`
     - Each row of a .csv file must have the same length as the header (not jagged)
     - An .xlsx file must be a valid excel workbook
@@ -255,6 +255,9 @@ When evaluating your file type checking security posture, keep in mind that `"st
     Boolean values are deprecated. Until version 8, `True` maps to `"strict"`,
     and `False` maps to `None`. In version 8, providing boolean values will
     raise an exception.
+
+    The default value changed to `"lenient"` from `False` (equivalent to `None`
+    during the deprecation period).
 
 .. note::
     Some files that look like artifacts from creating .zip archives on Macs,

--- a/docs/configuring/settings-beyond-the-ui.rst
+++ b/docs/configuring/settings-beyond-the-ui.rst
@@ -232,3 +232,32 @@ Once you've saved that change, restart Arches. Arches should now display more ac
 - Updated text contrast
 - Updated html to reflow properly on smaller screen sizes or when the screen is zoomed up to 400%
 - Updated text sizes to use relative sizing
+
+File type checking
+------------------
+Through the `FILE_TYPE_CHECKING` setting, Arches provides three modes for file type checking:
+
+- `None``: files can be uploaded regardless of the `FILE_TYPES` setting. In addition, the integrity checks described below for .zip, .xlsx, and .csv files are skipped.
+- `"lenient"`: if the type of the uploaded file can be guessed, the following checks are performed:
+    - The guessed file type must be included in `FILE_TYPES`
+    - Each row of a .csv file must have the same length as the header (not jagged)
+    - An .xlsx file must be a valid excel workbook
+    - .csv and .json files must be parsable
+    - Files inside a .zip archive will be tested against all of the above
+- `"strict"`: In addition to the above checks, files for which a type cannot be detected are rejected.
+
+When evaluating your file type checking security posture, keep in mind that `"strict"` mode will prevent uploading of simple `.txt` files, as there is no well-known type for them.
+
+.. versionadded:: 7.6
+    The `"lenient"` option.
+
+.. versionchanged:: 7.6
+    Boolean values are deprecated. Until version 8, `True` maps to `"strict"`,
+    and `False` maps to `None`. In version 8, providing boolean values will
+    raise an exception.
+
+.. note::
+    Some files that look like artifacts from creating .zip archives on Macs,
+    such as files beginning with "__MACOSX" or ending with "DS_Store" are
+    currently permitted when contained in .zip archives, even in strict mode,
+    but this behavior may change in future versions of Arches.

--- a/docs/configuring/settings-beyond-the-ui.rst
+++ b/docs/configuring/settings-beyond-the-ui.rst
@@ -237,7 +237,7 @@ File type checking
 ------------------
 Through the `FILE_TYPE_CHECKING` setting, Arches provides three modes for file type checking:
 
-- `None``: files can be uploaded regardless of the `FILE_TYPES` setting. In addition, the integrity checks described below for .zip, .xlsx, and .csv files are skipped.
+- `None`: files can be uploaded regardless of the `FILE_TYPES` setting. In addition, the integrity checks described below for .csv, .zip, .xlsx, and .json files are skipped.
 - `"lenient"`: if the type of the uploaded file can be guessed, the following checks are performed:
     - The guessed file type must be included in `FILE_TYPES`
     - Each row of a .csv file must have the same length as the header (not jagged)

--- a/docs/examples/arches/function.py
+++ b/docs/examples/arches/function.py
@@ -28,7 +28,7 @@ class Function(models.Model):
                 import_success = True
             except ImportError as e:
                 import_error = e
-            if module != None:
+            if module is not None:
                 break
         if import_success == False:
             print('Failed to import ' + mod_path)

--- a/docs/examples/sample_datatype.py
+++ b/docs/examples/sample_datatype.py
@@ -38,7 +38,7 @@ class SampleDataType(BaseDataType):
         document["strings"].append({"string": nodevalue, "nodegroup_id": tile.nodegroup_id})
 
     def transform_export_values(self, value, *args, **kwargs):
-        if value != None:
+        if value is not None:
             return value.encode("utf8")
 
     def get_search_terms(self, nodevalue, nodeid=None):


### PR DESCRIPTION
### brief description of changes
Document the three modes for file type checking, see https://github.com/archesproject/arches/pull/10863.

This box **must** be checked
- [x] the PR branch was originally made from the base branch

This box **should** be checked
- [ ] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [ ] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
