### PR TITLE
Fixed CLI docs for mapping file, only 1 graph UUID allowed

### DIFF
--- a/docs/developing/reference/command-line-reference.rst
+++ b/docs/developing/reference/command-line-reference.rst
@@ -304,7 +304,7 @@ models, branches, thesauri, and collections intact.
     python manage.py packages -o create_mapping_file -d 'path_to_destination_directory' -g 'comma separated graph uuids'
 
 -d  Path to directory to place the output in.
--g  One or more graph UUIDs to create a mapping for.
+-g  The graph UUID for which to create a mapping.
 
 This mimics the 'Create Mapping File' command from the Arches Designer UI.
 


### PR DESCRIPTION
### brief description of changes
Fix error where the CLI documentation incorrectly said multiple graph IDs were allowed in a mapping file

#### issues addressed
[<!-- feel free to delete this header if the PR does not specifically address an issue -->](https://github.com/archesproject/arches-docs/issues/444)

#### further comments
<!-- feel free to delete this header if you have no comments -->

---

This box **must** be checked
- [x] the PR branch was originally made from the base branch

This box **should** be checked
- [x] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [x] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
