### PR TITLE
Add context for startproject arguments

### DIFF
--- a/docs/developing/reference/command-line-reference.rst
+++ b/docs/developing/reference/command-line-reference.rst
@@ -54,7 +54,9 @@ creating an Arches project
     If `-d` is not specified, the new project will be created in the current working directory
     with the name of the project. To match python package `naming conventions
     <https://peps.python.org/pep-0008/#package-and-module-names>`_,
-    underscores ( `_`) will be replaced with dashes ( `-` ) in that directory name.
+    underscores (`_`) will be replaced with dashes (`-`) in that directory name, 
+    which is important if you plan on publishing your project to PyPi as an 
+    :ref:`Arches Application<Creating Applications>`.
 
 
 

--- a/docs/developing/reference/command-line-reference.rst
+++ b/docs/developing/reference/command-line-reference.rst
@@ -50,6 +50,11 @@ creating an Arches project
 
 -d, --directory
     (Optional) The name of the directory you'd like your new project located in.
+    
+    If `-d` is not specified, the new project will be created in the current working directory
+    with the name of the project. To match python package `naming conventions
+    <https://peps.python.org/pep-0008/#package-and-module-names>`_,
+    underscores ( `_`) will be replaced with dashes ( `-` ) in that directory name.
 
 
 

--- a/docs/installing/installation.rst
+++ b/docs/installing/installation.rst
@@ -101,7 +101,8 @@ Create a Project
 
 .. note::
 
-    You can add ``--directory path/to/dir`` to change the directory your new project will be created in.
+    You can add ``--directory path/to/dir`` to change the directory your new project will be created in. 
+    Additional details in the :ref:`command line reference<creating an Arches project>`.
 
 
 .. warning::


### PR DESCRIPTION
### brief description of changes
<!-- please describe the changes here -->

We have updated the [behavior of startproject](https://github.com/archesproject/arches/pull/12059) regarding creating a project directory and [nudging implementers towards](https://github.com/archesproject/arches/issues/12028) python package naming conventions.

---

This box **must** be checked
- [x] the PR branch was originally made from the base branch

This box **should** be checked
- [x] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [ ] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
