### PR TITLE
Update illustration of permissions UI in v8

### DIFF
--- a/docs/administering/designing-the-database.rst
+++ b/docs/administering/designing-the-database.rst
@@ -54,11 +54,7 @@ During the graph construction process, you are able to create a new Branch from 
 
 .. note:: If you are building a graph that uses an ontology, the ontology rules will automatically be enforced during this graph construction process.
 
-Along the way, you can use the preview button to display the graph in a more graph-like manner. This view will be familiar to users of Arches going back to version 3.0.
 
-.. figure:: ../images/graph-designer-graph-tab-preview.png
-
-   Screenshot of the Graph Tab in the Graph Designer, showing the graph in preview mode.
 
 Core Arches Datatypes
 ---------------------

--- a/docs/administering/designing-the-database.rst
+++ b/docs/administering/designing-the-database.rst
@@ -144,6 +144,15 @@ Arches allows you to define permissions at the card level. Because of publicatio
 
    Animation showing the activation of the Permissions Tab in the Graph Designer.
 
+
+Below, you can see a screenshot of the Permissions Tab in the Graph Designer for Arches version 7 and earlier. Note that the interface has changed in version 8, but the functionality is the same.
+
+
+.. figure:: ../images/graph-designer-permissions-tab.png
+
+   Screenshot of the Version 7 (and earlier) Permissions Tab in the Graph Designer.
+
+
 Once you have selected one or more cards, you can select a user or user group and then assign one of the following permissions levels:
 
 :Delete: Allows users to delete instances of this nodegroup. Note, this is not the same as being allowed to delete an entire resource, permissions for which are not handled here.

--- a/docs/administering/designing-the-database.rst
+++ b/docs/administering/designing-the-database.rst
@@ -37,7 +37,7 @@ Graph Designer
 
 Almost all aspects of Resource Model and Branch design are handled in the Graph Designer. The exception is Functions, which are handled in the separate Function Manager.
 
-The Graph Designer comprises three tabs, the `Graph Tab`_, `Cards Tab`_, and `Permissions Tab`_. Each tab is used to configure a different aspect of the Resource Model: In the Graph Tab you design the node structure, in the Cards Tab you configure the user interface (card) for each nodegroup, and in the Permissions Tab you are able to assign detailed permission levels to each card. The general workflow for using the Graph Designer is to proceed through the tabs in that same order.
+The Graph Designer comprises three tabs, the `Graph Tab`_, `Cards Tab`_, and `Permissions Tab`_ (the Permissions Tab is available after you click the "Make changes without publishing" option). Each tab is used to configure a different aspect of the Resource Model: In the Graph Tab you design the node structure, in the Cards Tab you configure the user interface (card) for each nodegroup, and in the Permissions Tab you are able to assign detailed permission levels to each card. The general workflow for using the Graph Designer is to proceed through the tabs in that same order.
 
 Graph Tab
 ---------
@@ -142,11 +142,11 @@ The **Related Resources Map Card** enables a more rich user experience for nodes
 Permissions Tab
 ---------------
 
-Arches allows you to define permissions at the card level, so in the Permissions Tab you'll see the card tree, just as in the Cards tab. However, you will only be able to select entire cards, not individual nodes.
+Arches allows you to define permissions at the card level. Because of publication changes to Graphs in version 8, the `Permissions Tab` has been moved from its location in earlier versions of Arches. To access permissions, click the button "Make changes without publishing" (see the animation below). Note, you will only be able to select entire cards, not individual nodes.
 
-.. figure:: ../images/graph-designer-permissions-tab.png
+.. figure:: ../images/arches-ui-permissions-v8.gif
 
-   Screenshot of the Permissions Tab in the Graph Designer, showing an "Actor" Resource Model.
+   Animation showing the activation of the Permissions Tab in the Graph Designer.
 
 Once you have selected one or more cards, you can select a user or user group and then assign one of the following permissions levels:
 


### PR DESCRIPTION
### brief description of changes
Added an animation and explanation on how to activate the Permissions tab in v8. See the update tested here: https://arches.readthedocs.io/en/perm_v8/administering/designing-the-database/#permissions-tab

I also eliminated the obsolete graph visualization that is no longer supported in Arches designer.

#### issues addressed
https://github.com/archesproject/arches-docs/issues/485

https://github.com/archesproject/arches-docs/issues/487

#### further comments
Yes, v8 graph publishing workflows seem to require a bit update of documentation. But this is a useful first step.

---

This box **must** be checked
- [x] the PR branch was originally made from the base branch

This box **should** be checked
- [x] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [x] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
