### PR TITLE
Update EDTF reference

### DIFF
--- a/docs/developing/reference/import-export.rst
+++ b/docs/developing/reference/import-export.rst
@@ -49,10 +49,10 @@ Format must be YYYY-MM-DD, no quotes::
 edtf
 ----
 
-Must be a valid `Extended Date Time Format <https://www.loc.gov/standards/datetime/pre-submission.html>`_ string::
+Must be a valid `Extended Date Time Format <https://www.loc.gov/standards/datetime/edtf.html>`_ string::
 
     "2010-10"
-    "-y10000"
+    "Y-10000"
 
 Arches supports level 2 of the EDTF specification. However, because of a bug in the edtf package used by Arches,
 an error will be thrown for strings like::
@@ -63,6 +63,7 @@ As a workaround, you can use a string like::
 
     "[../1924]"
 
+An `Extended Date Time Format validator is available <https://digital2.library.unt.edu/edtf/>`_.
 
 geojson-feature-collection
 --------------------------


### PR DESCRIPTION
### brief description of changes
<!-- please describe the changes here -->
 - Reflect changes on Library of Congress website and update EDTF specification URL. 
 - Example of a greater-than-four digit negative year was incorrect: A capital 'Y' is now required, and the minus sign precedes the number, not the 'Y'. 
 - Add a link to the EDTF validator at the University of North Texas.

---

This box **must** be checked
- [X ] the PR branch was originally made from the base branch

This box **should** be checked
- [ ] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [ ] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
