### PR TITLE
Added SESSION_COOKIE_SAMESITE caveat note

### DIFF
--- a/docs/developing/reference/api.rst
+++ b/docs/developing/reference/api.rst
@@ -121,6 +121,18 @@ To allow others to connect to your Arches instance, you must create an OAuth cli
     + Only make one application, though you are technically allowed to make more.
     + An application is "owned" by whichever user created it, and will not be visible to other users.
 
+
+.. important::
+
+    Be aware that a locked down setting for ``SESSION_COOKIE_SAMESITE`` in your Arches project's 
+    ``settings.py`` or ``settings_local.py`` file may overly restrict access in certain deployment scenarios.
+    If you expect your users to use the password reset links or external OAuth, you need to ensure that 
+    ``SESSION_COOKIE_SAMESITE`` is set to 'Lax'. While the "Strict" setting is technically more secure, 
+    a "Strict" setting will not load a session cookie for users that follow a hyperlink or a 
+    redirect from another site (e.g. from an external OAuth provider).
+
+
+
 Authentication
 ==============
 


### PR DESCRIPTION
### brief description of changes
Added @aarongundel 's note about OAuth settings.

#### issues addressed
[<!-- feel free to delete this header if the PR does not specifically address an issue -->](https://github.com/archesproject/arches-docs/issues/506)

#### further comments

See temporary demo in docs here: https://arches.readthedocs.io/en/oauth_8/developing/reference/api/#register-an-oauth-application

---

This box **must** be checked
- [X] the PR branch was originally made from the base branch

This box **should** be checked
- [X] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [X] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
